### PR TITLE
Emit Observer Coverage Events

### DIFF
--- a/.jules/exchange/events/cancellation_adapter_coverage_cov.md
+++ b/.jules/exchange/events/cancellation_adapter_coverage_cov.md
@@ -1,0 +1,28 @@
+---
+label: "tests"
+created_at: "2024-03-25"
+author_role: "cov"
+confidence: "high"
+---
+
+## Problem
+
+The error handling branches inside `cancellationAwareDelay` in `src/adapters/cancellation-aware-delay.ts` are uncovered by tests, creating a risk that runtime errors during signal handler installation or timeout scheduling will silently cause test failures or production freezes without proper verification.
+
+## Goal
+
+Add tests to ensure that `cancellationAwareDelay` robustly propagates errors when `process.on` or `setTimeout` fail.
+
+## Context
+
+The coverage report clearly shows that lines 48-54 (signal handler installation try-catch), 58-59 (scheduleNextChunk early return for settled state), and 76-77 (setTimeout try-catch) in `src/adapters/cancellation-aware-delay.ts` are uncovered. Given that this code is an adapter at the boundary of the Node.js event loop and specifically deals with cancellation, verifying its error paths is critical to prevent hangs in the GitHub Action environment.
+
+## Evidence
+
+- path: "src/adapters/cancellation-aware-delay.ts"
+  loc: "48-54, 58-59, 76-77"
+  note: "Coverage report explicitly marks these lines as uncovered. They represent error handling and early-exit conditions in the delay adapter."
+
+## Change Scope
+
+- `tests/adapters/cancellation-aware-delay.test.ts`

--- a/.jules/exchange/events/index_bootstrap_coverage_cov.md
+++ b/.jules/exchange/events/index_bootstrap_coverage_cov.md
@@ -1,0 +1,29 @@
+---
+label: "tests"
+created_at: "2024-03-25"
+author_role: "cov"
+confidence: "high"
+---
+
+## Problem
+
+The `src/index.ts` bootstrap file has 0% coverage. While bootstrapping code is often excluded, its error handling—specifically how `WaitCancelledError` and generic errors translate into GitHub Action notices and exit codes—is critical to the reliability of the action. Without coverage, changes could easily break the contract of correctly reporting wait cancellations versus fatal errors.
+
+## Goal
+
+Add testing for the top-level execution paths, verifying that `run()` sets the correct outputs and that unhandled rejections result in appropriate exit codes and error logs. Alternatively, encapsulate the exit-code logic in an explicitly tested module and keep `index.ts` purely declarative.
+
+## Context
+
+`src/index.ts` is the runtime entrypoint. If it fails to catch or translate exceptions correctly, the GitHub Action might crash silently or return confusing exit codes. The `WaitCancelledError` translation to specific exit codes (130 for SIGINT, 143 for SIGTERM) is an important part of the expected behavior, but the logic in `signalExitCode` is currently untested.
+
+## Evidence
+
+- path: "src/index.ts"
+  loc: "1-46"
+  note: "The entire file is reported as 0% coverage. Lines 24-46 define critical logic for translating runtime errors into process exit states, which must be verified."
+
+## Change Scope
+
+- `src/index.ts`
+- `tests/index.test.ts` (new)


### PR DESCRIPTION
Emit coverage events for `cancellation-aware-delay.ts` and `index.ts` detailing critical paths that are currently uncovered.

---
*PR created automatically by Jules for task [1856356526880585579](https://jules.google.com/task/1856356526880585579) started by @akitorahayashi*