### PR TITLE
docs: emit qa observer events for test quality improvements

### DIFF
--- a/.jules/exchange/events/missing_chunked_delay_coverage_qa.md
+++ b/.jules/exchange/events/missing_chunked_delay_coverage_qa.md
@@ -1,0 +1,36 @@
+---
+label: "tests"
+created_at: "2025-03-25"
+author_role: "qa"
+confidence: "high"
+---
+
+## Problem
+
+`cancellationAwareDelay` has complex looping logic to handle delays longer than 60 seconds (chunking), but there are no tests verifying this behavior. The maximum tested duration is 60 seconds.
+
+## Goal
+
+Add a test for `cancellationAwareDelay` that verifies it correctly loops for durations > 60 seconds and still responds to cancellation signals during subsequent chunks.
+
+## Context
+
+The `cancellationAwareDelay` adapter contains an internal loop (`scheduleNextChunk`) to process long delays in 60-second increments (`SECONDS_PER_DELAY_CHUNK`). This is a critical piece of logic to prevent Node.js from warning about excessively large timeouts or hitting maximum timeout limits. The tests in `tests/adapters/cancellation-aware-delay.test.ts` only cover up to 60 seconds, leaving the looping logic completely untested. An error in the remaining duration calculation or re-scheduling could cause incorrect behavior for long waits.
+
+## Evidence
+
+- path: "tests/adapters/cancellation-aware-delay.test.ts"
+  loc: "44-51"
+  note: "Test `resolves after the requested duration` only tests a 2-second delay."
+
+- path: "tests/adapters/cancellation-aware-delay.test.ts"
+  loc: "53-69"
+  note: "Test `cancels promptly on SIGINT` only tests a 60-second delay (the exact chunk size), never triggering the >60s loop condition."
+
+- path: "tests/adapters/cancellation-aware-delay.test.ts"
+  loc: "71-87"
+  note: "Test `cancels promptly on SIGTERM` also only tests a 60-second delay."
+
+## Change Scope
+
+- `tests/adapters/cancellation-aware-delay.test.ts`

--- a/.jules/exchange/events/process_mock_swallows_events_qa.md
+++ b/.jules/exchange/events/process_mock_swallows_events_qa.md
@@ -1,0 +1,32 @@
+---
+label: "tests"
+created_at: "2025-03-25"
+author_role: "qa"
+confidence: "high"
+---
+
+## Problem
+
+The test utility `captureSignalHandlers` in `cancellation-aware-delay.test.ts` replaces `process.on` and `process.off` with spies, but its mock implementation swallows all events that are not `'SIGINT'` or `'SIGTERM'`.
+
+## Goal
+
+Fix the `captureSignalHandlers` mock to delegate non-signal events back to the original `process.on` and `process.off` implementations, so the test runner or other libraries are not disrupted.
+
+## Context
+
+In `tests/adapters/cancellation-aware-delay.test.ts`, the `captureSignalHandlers` function uses `vi.spyOn(process, 'on').mockImplementation(...)`. If the event is not `SIGINT` or `SIGTERM`, it simply returns `process` without actually registering the listener with the real `process.on`. This can cause unpredictable and flaky behavior in tests if the test runner (like vitest) or other parts of the Node process attempt to register event listeners (e.g., for `uncaughtException`, `unhandledRejection`, `exit`, etc.) while the mock is active. The original behavior must be preserved for any unrelated event.
+
+## Evidence
+
+- path: "tests/adapters/cancellation-aware-delay.test.ts"
+  loc: "14-22"
+  note: "The `onSpy` mock implementation checks if the event is SIGINT or SIGTERM, but returns `process` unconditionally without calling the original `process.on` for other events."
+
+- path: "tests/adapters/cancellation-aware-delay.test.ts"
+  loc: "24-30"
+  note: "The `offSpy` mock implementation has the same issue, swallowing removal of listeners for all other events."
+
+## Change Scope
+
+- `tests/adapters/cancellation-aware-delay.test.ts`

--- a/.jules/exchange/events/redundant_domain_validation_in_action_qa.md
+++ b/.jules/exchange/events/redundant_domain_validation_in_action_qa.md
@@ -1,0 +1,40 @@
+---
+label: "tests"
+created_at: "2025-03-25"
+author_role: "qa"
+confidence: "high"
+---
+
+## Problem
+
+The tests for the `readInputs` action adapter redundantly test domain-layer logic (boolean parsing and duration normalization) instead of just verifying that it correctly delegates raw inputs to the domain layer.
+
+## Goal
+
+Remove redundant tests in `tests/action/read-inputs.test.ts` that duplicate the domain layer tests (`tests/domain/duration.test.ts` and `tests/domain/wait-request.test.ts`), focusing only on the adapter logic (reading inputs from `@actions/core`).
+
+## Context
+
+`src/action/read-inputs.ts` retrieves strings from `@actions/core` and passes them to `normalizeWaitRequest`. The domain layer is responsible for parsing booleans, dropping empty labels, and resolving effective seconds. However, `tests/action/read-inputs.test.ts` asserts detailed behavior like rejecting non-integer seconds, dropping empty labels, parsing booleans (e.g. `enabled=off`), and prioritizing seconds over minutes. This violates the testing principle: "Tests assert externally observable behavior at the owning boundary, never duplicated knowledge of internal implementation". These tests are coupled to the domain layer's rules and will need to be updated unnecessarily if the domain logic changes.
+
+## Evidence
+
+- path: "tests/action/read-inputs.test.ts"
+  loc: "54-63"
+  note: "Test `parses false enabled values` tests the string parsing of `off`, which is already handled in `normalizeWaitRequest`."
+
+- path: "tests/action/read-inputs.test.ts"
+  loc: "65-74"
+  note: "Test `trims labels and keeps non-empty values` duplicates testing of empty label handling."
+
+- path: "tests/action/read-inputs.test.ts"
+  loc: "76-87"
+  note: "Test `fails for unrecognized boolean values` re-tests error throwing for unrecognized tokens."
+
+- path: "tests/action/read-inputs.test.ts"
+  loc: "26-52"
+  note: "Tests for authoritative duration sources and minute conversions are re-testing `resolveEffectiveSeconds`."
+
+## Change Scope
+
+- `tests/action/read-inputs.test.ts`


### PR DESCRIPTION
Emitted 3 QA event files documenting areas for test quality improvement in accordance with the QA role focus on failure diagnosability, determinism, and redundancy.

---
*PR created automatically by Jules for task [11197719645704991124](https://jules.google.com/task/11197719645704991124) started by @akitorahayashi*