### PR TITLE
Add data architecture observations

### DIFF
--- a/.jules/exchange/events/implicit_validation_errors_data_arch.md
+++ b/.jules/exchange/events/implicit_validation_errors_data_arch.md
@@ -1,0 +1,36 @@
+---
+label: "refacts"
+created_at: "2026-03-25"
+author_role: "data_arch"
+confidence: "high"
+---
+
+## Problem
+
+Validation failures for inputs (e.g., non-negative integers or recognized booleans) implicitly throw generic `Error` instances instead of explicitly modeling errors (e.g., via Result types or typed validation errors).
+
+## Goal
+
+Encode invariants and validation failures explicitly so invalid states are hard to express and errors are handled comprehensively without implicit panics/unwraps.
+
+## Context
+
+Using `throw new Error(...)` for expected validation issues obscures the data flow and prevents callers from handling specific error states programmatically. It violates the "Represent Valid States Only" principle and explicit error modeling guidelines.
+
+## Evidence
+
+- path: "src/domain/duration.ts"
+  loc: "25-27"
+  note: "`parseNonNegativeInteger` throws a generic `Error` if the regex fails."
+- path: "src/domain/wait-request.ts"
+  loc: "40-42"
+  note: "`parseBooleanInput` throws a generic `Error` when the boolean value is unrecognized."
+- path: "src/index.ts"
+  loc: "24-27"
+  note: "The top-level handler blindly catches `Error` and calls `core.setFailed`, lacking typed error differentiation."
+
+## Change Scope
+
+- `src/domain/duration.ts`
+- `src/domain/wait-request.ts`
+- `src/index.ts`

--- a/.jules/exchange/events/redundant_duration_inputs_data_arch.md
+++ b/.jules/exchange/events/redundant_duration_inputs_data_arch.md
@@ -1,0 +1,35 @@
+---
+label: "refacts"
+created_at: "2026-03-25"
+author_role: "data_arch"
+confidence: "high"
+---
+
+## Problem
+
+The definition of time parameters (`minutes` and `seconds`) is duplicated across `DurationInputs` and `RawWaitInputs`.
+
+## Goal
+
+Consolidate the definition of input wait parameters so there's a single source of truth for all action inputs, avoiding repetitive types and explicit translation mapping.
+
+## Context
+
+The Single Source of Truth principle dictates that a concept should only be modeled once. Having `minutes` and `seconds` on both `RawWaitInputs` and `DurationInputs` causes mapping logic (`normalizeWaitRequest` calling `resolveEffectiveSeconds({ minutes: raw.minutes, seconds: raw.seconds })`) that creates unnecessary coupling and potential drift.
+
+## Evidence
+
+- path: "src/domain/duration.ts"
+  loc: "1-4"
+  note: "`DurationInputs` defines `minutes?: string` and `seconds?: string`."
+- path: "src/domain/wait-request.ts"
+  loc: "9-14"
+  note: "`RawWaitInputs` redundantly defines `minutes?: string` and `seconds?: string` alongside other inputs."
+- path: "src/domain/wait-request.ts"
+  loc: "19-20"
+  note: "`normalizeWaitRequest` unpacks these parameters explicitly to pass them into `resolveEffectiveSeconds`."
+
+## Change Scope
+
+- `src/domain/duration.ts`
+- `src/domain/wait-request.ts`

--- a/.jules/exchange/events/transport_dtos_in_domain_data_arch.md
+++ b/.jules/exchange/events/transport_dtos_in_domain_data_arch.md
@@ -1,0 +1,36 @@
+---
+label: "refacts"
+created_at: "2026-03-25"
+author_role: "data_arch"
+confidence: "high"
+---
+
+## Problem
+
+Transport DTOs (`RawWaitInputs`, `DurationInputs`) and raw string-parsing logic (`parseBooleanInput`, `parseNonNegativeInteger`) are improperly located within the core `domain` layer instead of at the boundaries.
+
+## Goal
+
+Move raw input schemas and parsing logic out of the `domain` layer and into the boundary layers (e.g., `action/read-inputs.ts`), so the domain only deals with valid, parsed types.
+
+## Context
+
+The domain should remain independent of transport/UI/runtime concerns. Currently, `src/domain/wait-request.ts` and `src/domain/duration.ts` handle string inputs directly from the GitHub Actions runner environment, which violates the Boundary Sovereignty principle.
+
+## Evidence
+
+- path: "src/domain/duration.ts"
+  loc: "1-4, 20-30"
+  note: "`DurationInputs` is a DTO that accepts string values, and `parseNonNegativeInteger` handles transport-level parsing."
+- path: "src/domain/wait-request.ts"
+  loc: "9-14, 25-42"
+  note: "`RawWaitInputs` defines raw string inputs, and `parseBooleanInput` parses these raw values inside the domain."
+- path: "src/action/read-inputs.ts"
+  loc: "4-10"
+  note: "This boundary entry point relies on `normalizeWaitRequest` inside the domain layer instead of doing the parsing itself."
+
+## Change Scope
+
+- `src/domain/duration.ts`
+- `src/domain/wait-request.ts`
+- `src/action/read-inputs.ts`


### PR DESCRIPTION
Added three event files under `.jules/exchange/events/` identifying key data architecture improvements for the repository. The findings focus on:
1. Transport DTOs (`RawWaitInputs`, `DurationInputs`) and string-parsing logic being improperly located in the core `domain` layer instead of at the boundaries.
2. The use of generic `Error` exceptions for expected validation failures (e.g., non-negative integers or recognized booleans), which violates explicit error modeling.
3. The duplication of time parameters (`minutes` and `seconds`) across `DurationInputs` and `RawWaitInputs`, resulting in unnecessary mappings and a lack of a single source of truth.

All events are formatted according to the provided schema and contain concrete, file-level evidence to support the architectural improvements.

---
*PR created automatically by Jules for task [3641951294516050298](https://jules.google.com/task/3641951294516050298) started by @akitorahayashi*