### PR TITLE
docs: emit observer events for TypeScript codebase improvements

### DIFF
--- a/.jules/exchange/events/broad_signal_type_non_exhaustive_switch_typescripter.md
+++ b/.jules/exchange/events/broad_signal_type_non_exhaustive_switch_typescripter.md
@@ -1,0 +1,32 @@
+---
+label: "bugs"
+created_at: "2026-03-25"
+author_role: "typescripter"
+confidence: "high"
+---
+
+## Problem
+
+`WaitCancelledError` uses a broad `NodeJS.Signals` type, necessitating a `default` case in the `signalExitCode` switch statement, preventing exhaustive checking of known cancellation signals.
+
+## Goal
+
+Constrain the signal type for `WaitCancelledError` to an explicit union of handled signals (`'SIGINT' | 'SIGTERM'`) so that the `switch` statement can be exhaustively checked by the compiler.
+
+## Context
+
+The `typescripter` role explicitly outlines that state should be modeled with discriminated unions, switch statements should be exhaustive, and `never` should be used instead of relying on default cases. `NodeJS.Signals` is an overly broad type including signals that are never passed to the error. Because `WaitCancelledError.signal` is typed as `NodeJS.Signals`, the switch statement requires a default case, hiding missing or newly added signals, and failing the exhaustive check invariant.
+
+## Evidence
+
+- path: "src/adapters/cancellation-aware-delay.ts"
+  loc: "1-9"
+  note: "WaitCancelledError declares `signal: NodeJS.Signals` which is overly broad."
+- path: "src/index.ts"
+  loc: "35-43"
+  note: "`signalExitCode` uses a default case on the broad type instead of an exhaustive switch on a constrained union type."
+
+## Change Scope
+
+- `src/adapters/cancellation-aware-delay.ts`
+- `src/index.ts`

--- a/.jules/exchange/events/duration_inputs_invalid_combinations_typescripter.md
+++ b/.jules/exchange/events/duration_inputs_invalid_combinations_typescripter.md
@@ -1,0 +1,32 @@
+---
+label: "bugs"
+created_at: "2026-03-25"
+author_role: "typescripter"
+confidence: "high"
+---
+
+## Problem
+
+`DurationInputs` models state as a combination of optional string flags (`minutes?: string`, `seconds?: string`), permitting invalid or ambiguous combinations (e.g., both provided, neither provided).
+
+## Goal
+
+Model the duration input state using a discriminated union so that only valid, mutually exclusive inputs are representable, and exhaustively handle these states without silent fallbacks.
+
+## Context
+
+The `typescripter` role emphasizes making invalid states unrepresentable by using discriminated unions instead of loose optional fields. Currently, `resolveEffectiveSeconds` accepts the loose `DurationInputs` object. If both `seconds` and `minutes` are provided, it silently prioritizes `seconds` and ignores `minutes`. If neither is provided, it silently returns `0`. This violates the principle of explicitly failing on invalid states and avoiding silent fallbacks.
+
+## Evidence
+
+- path: "src/domain/duration.ts"
+  loc: "1-4"
+  note: "DurationInputs uses optional primitives, allowing invalid combinations like {minutes: '1', seconds: '60'} or {}."
+- path: "src/domain/duration.ts"
+  loc: "8-21"
+  note: "resolveEffectiveSeconds silently prioritizes seconds over minutes, and returns 0 if neither is provided, acting as a prohibited silent fallback."
+
+## Change Scope
+
+- `src/domain/duration.ts`
+- `src/domain/wait-request.ts`

--- a/.jules/exchange/events/swallowed_errors_cancellation_delay_typescripter.md
+++ b/.jules/exchange/events/swallowed_errors_cancellation_delay_typescripter.md
@@ -1,0 +1,31 @@
+---
+label: "bugs"
+created_at: "2026-03-25"
+author_role: "typescripter"
+confidence: "high"
+---
+
+## Problem
+
+Errors caught during event listener registration and setTimeout scheduling in `cancellationAwareDelay` are swallowed and replaced by generic messages without preserving the original error context.
+
+## Goal
+
+Preserve error context explicitly when wrapping failures in `cancellationAwareDelay` or handle them transparently according to the failure semantics.
+
+## Context
+
+The `typescripter` role forbids `catch` blocks that swallow errors or coerce them to `any`. In `cancellationAwareDelay`, there are `catch` blocks around `process.on` and `setTimeout` that catch `unknown` exceptions but do not log or pass the original error to the returned `Error`. This erases runtime evidence of why a cancellation handler installation or delay chunk scheduling failed.
+
+## Evidence
+
+- path: "src/adapters/cancellation-aware-delay.ts"
+  loc: "44-47"
+  note: "`process.on` block catches an exception and throws a generic 'Failed to install cancellation handlers.' error without passing or logging the underlying failure."
+- path: "src/adapters/cancellation-aware-delay.ts"
+  loc: "62-67"
+  note: "`setTimeout` block catches an exception and throws a generic 'Failed to start wait timer.' error, again swallowing the original error."
+
+## Change Scope
+
+- `src/adapters/cancellation-aware-delay.ts`


### PR DESCRIPTION
Emitted three high-signal event files from the `typescripter` observer role to document areas for TypeScript type-system and state modeling improvements:

1. `broad_signal_type_non_exhaustive_switch_typescripter.md`: Documents that `WaitCancelledError` uses a broad `NodeJS.Signals` type, causing `signalExitCode` to require a default case instead of an exhaustive switch on a constrained union of handled signals (`'SIGINT' | 'SIGTERM'`).
2. `duration_inputs_invalid_combinations_typescripter.md`: Documents that `DurationInputs` encodes state using optional primitives, allowing invalid combinations and leading to a silent fallback in `resolveEffectiveSeconds`.
3. `swallowed_errors_cancellation_delay_typescripter.md`: Documents that `catch` blocks in `cancellationAwareDelay` swallow errors and replace them with generic messages, failing to preserve original error context.

---
*PR created automatically by Jules for task [1846617919231081896](https://jules.google.com/task/1846617919231081896) started by @akitorahayashi*