### PR TITLE
test: remove redundant domain logic tests from read-inputs adapter

### DIFF
--- a/tests/action/read-inputs.test.ts
+++ b/tests/action/read-inputs.test.ts
@@ -1,16 +1,22 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import * as core from '@actions/core'
 import { readInputs } from '../../src/action/read-inputs'
+import { normalizeWaitRequest } from '../../src/domain/wait-request'
 
 vi.mock('@actions/core', () => ({
   getInput: vi.fn(),
 }))
 
+vi.mock('../../src/domain/wait-request', () => ({
+  normalizeWaitRequest: vi.fn(),
+}))
+
 const mockedGetInput = vi.mocked(core.getInput)
+const mockedNormalizeWaitRequest = vi.mocked(normalizeWaitRequest)
 
 describe('readInputs', () => {
   afterEach(() => {
-    mockedGetInput.mockReset()
+    vi.resetAllMocks()
   })
 
   it('reads and trims inputs before passing them to the domain layer', () => {
@@ -29,9 +35,12 @@ describe('readInputs', () => {
       }
     })
 
-    expect(readInputs()).toEqual({
-      enabled: false,
-      effectiveSeconds: 10,
+    readInputs()
+
+    expect(mockedNormalizeWaitRequest).toHaveBeenCalledWith({
+      enabled: 'false',
+      minutes: '2',
+      seconds: '10',
       label: 'my label',
     })
   })
@@ -39,9 +48,12 @@ describe('readInputs', () => {
   it('treats empty or whitespace-only inputs as absent', () => {
     mockedGetInput.mockReturnValue('   ')
 
-    expect(readInputs()).toEqual({
-      enabled: true,
-      effectiveSeconds: 0,
+    readInputs()
+
+    expect(mockedNormalizeWaitRequest).toHaveBeenCalledWith({
+      enabled: undefined,
+      minutes: undefined,
+      seconds: undefined,
       label: undefined,
     })
   })


### PR DESCRIPTION
Removed tests in `tests/action/read-inputs.test.ts` that verified detailed behavior like minutes conversion, handling non-integer input, parsing boolean strings, and rejecting non-integers, which belong in the domain-layer. Replaced them with pure adapter logic tests that verify `readInputs` successfully fetches, trims, and passes inputs down to the domain layer.

---
*PR created automatically by Jules for task [9997828119607356024](https://jules.google.com/task/9997828119607356024) started by @akitorahayashi*