### PR TITLE
test: Emit QA events for mock coupling

### DIFF
--- a/.jules/exchange/events/cancellation_delay_mock_coupling_qa.md
+++ b/.jules/exchange/events/cancellation_delay_mock_coupling_qa.md
@@ -1,0 +1,31 @@
+---
+label: "tests"
+created_at: "2025-02-18"
+author_role: "qa"
+confidence: "high"
+---
+
+## Problem
+
+The test `tests/adapters/cancellation-aware-delay.test.ts` is overly coupled to the implementation details of `cancellationAwareDelay`. It relies on heavy mocking of `process.on`, `process.off`, and `setTimeout`, and uses a complex `captureSignalHandlers` helper.
+
+## Goal
+
+Refactor the test to validate externally visible behavior rather than internal implementation details, ensuring it relies less on mocking the Node.js event loop and signal management.
+
+## Context
+
+Tests should be resilient to internal refactoring. Because `cancellation-aware-delay.test.ts` heavily spies and mocks `process` and `setTimeout`, any change to the underlying timer mechanism (like adopting `timers/promises` or changing how chunks are processed) will break the test, causing brittleness and high maintenance costs.
+
+## Evidence
+
+- path: "tests/adapters/cancellation-aware-delay.test.ts"
+  loc: "captureSignalHandlers"
+  note: "This complex helper mocks `process.on` and `process.off` directly instead of observing external effects."
+- path: "tests/adapters/cancellation-aware-delay.test.ts"
+  loc: "setTimeoutSpy"
+  note: "Spies on `global.setTimeout` directly instead of relying solely on `vi.useFakeTimers()` external behavior control."
+
+## Change Scope
+
+- `tests/adapters/cancellation-aware-delay.test.ts`

--- a/.jules/exchange/events/index_mock_coupling_qa.md
+++ b/.jules/exchange/events/index_mock_coupling_qa.md
@@ -1,0 +1,31 @@
+---
+label: "tests"
+created_at: "2025-02-18"
+author_role: "qa"
+confidence: "high"
+---
+
+## Problem
+
+`tests/index.test.ts` over-couples to its internal implementation details by heavily mocking its own internal modules (`readInputs`, `executeWait`, `emitOutputs`, `cancellationAwareDelay`).
+
+## Goal
+
+Refactor the entrypoint test to act as a proper boundary or seam test. It should avoid stubbing out the entire application layer (`executeWait`) and input/output layer (`readInputs`, `emitOutputs`), and instead focus on testing the observable outcomes of the execution path, treating the internal modules as a black box where possible.
+
+## Context
+
+The main action file (`index.ts`) orchestrates the overall flow. Tests that mock out all internal dependencies provide little value in verifying that the integrated components actually work together correctly. This makes the test brittle during refactors when module boundaries change (e.g., if logic is moved between `readInputs` and `executeWait`).
+
+## Evidence
+
+- path: "tests/index.test.ts"
+  loc: "line 6-18"
+  note: "Mocks `../src/action/read-inputs`, `../src/app/execute-wait`, and `../src/action/emit-outputs` rather than testing the real coordination."
+- path: "tests/index.test.ts"
+  loc: "line 40-42"
+  note: "Relies on verifying that specific mocked functions were called with specific arguments, rather than validating external state changes or outcomes."
+
+## Change Scope
+
+- `tests/index.test.ts`


### PR DESCRIPTION
Added two event files documenting test structural issues related to over-mocking and coupling to internal details, specifically for `cancellationAwareDelay` and the entrypoint `index.test.ts`.

---
*PR created automatically by Jules for task [1216094167609150727](https://jules.google.com/task/1216094167609150727) started by @akitorahayashi*