### PR TITLE
chore(taxonomy): emit taxonomy events

### DIFF
--- a/.jules/exchange/events/domain_inputs_leak_taxonomy.md
+++ b/.jules/exchange/events/domain_inputs_leak_taxonomy.md
@@ -1,0 +1,34 @@
+---
+label: "refacts"
+created_at: "2024-03-27"
+author_role: "taxonomy"
+confidence: "high"
+---
+
+## Problem
+
+Transport vocabulary leaking into the Domain. The term "Inputs", which is specific to GitHub Actions transport mechanics (`core.getInput()`), appears in core Domain structures (`RawWaitInputs`, `DurationInputs`).
+
+## Goal
+
+Decouple Domain concepts from Transport details. Re-name domain types to reflect unvalidated state or requests, reserving "Inputs" strictly for the `src/action` transport boundary.
+
+## Context
+
+The domain files `wait-request.ts` and `duration.ts` define types `RawWaitInputs` and `DurationInputs`. This implies the domain is aware of how it is invoked (via GitHub Action inputs). The Domain should model the problem space independently. A more domain-appropriate name for unparsed, transport-agnostic data would be something like `RawWaitRequest` and `RawDuration` or `UnvalidatedDuration`.
+
+## Evidence
+
+- path: "src/domain/wait-request.ts"
+  loc: "line 9"
+  note: "`RawWaitInputs` uses the word 'Inputs', leaking the action input concept into the Domain layer."
+
+- path: "src/domain/duration.ts"
+  loc: "line 1"
+  note: "`DurationInputs` uses the word 'Inputs', unnecessarily associating raw temporal duration values with the action transport mechanism."
+
+## Change Scope
+
+- `src/domain/wait-request.ts`
+- `src/domain/duration.ts`
+- `src/action/read-inputs.ts`

--- a/.jules/exchange/events/wait_vs_delay_taxonomy.md
+++ b/.jules/exchange/events/wait_vs_delay_taxonomy.md
@@ -1,0 +1,35 @@
+---
+label: "refacts"
+created_at: "2024-03-27"
+author_role: "taxonomy"
+confidence: "high"
+---
+
+## Problem
+
+Synonym collision between "Wait" and "Delay". The terms are used interchangeably across domain and adapter boundaries, creating confusion about the canonical concept.
+
+## Goal
+
+Establish "Wait" as the canonical domain term for the act of suspending execution, and reserve "Delay" (if used at all) strictly for low-level technical timer implementations. Avoid mixing the two in the same logical layer.
+
+## Context
+
+The repository represents a GitHub Action designed to "wait" for a duration. The domain speaks of `WaitRequest` and `WaitResult`, but the application layer (`executeWait`) relies on an injected `ExecuteWaitDependencies.delay` function. Furthermore, the adapter `cancellationAwareDelay` throws a `WaitCancelledError`, mixing the two concepts in a single file. This violates the "One Concept, One Preferred Term" principle.
+
+## Evidence
+
+- path: "src/app/execute-wait/execute-wait-dependencies.ts"
+  loc: "line 2"
+  note: "Domain application boundary `ExecuteWaitDependencies` uses `delay: (seconds: number) => Promise<void>` instead of `wait`."
+
+- path: "src/adapters/cancellation-aware-delay.ts"
+  loc: "lines 4-13, 17"
+  note: "The function is named `cancellationAwareDelay` but it explicitly throws `WaitCancelledError`, mixing 'wait' and 'delay' in the same context."
+
+## Change Scope
+
+- `src/app/execute-wait/execute-wait-dependencies.ts`
+- `src/app/execute-wait/index.ts`
+- `src/adapters/cancellation-aware-delay.ts`
+- `src/index.ts`


### PR DESCRIPTION
Emitted two event files based on taxonomy observations:
1. `wait_vs_delay_taxonomy.md`: Highlighted the synonym collision between the "Wait" domain term and the "Delay" adapter term.
2. `domain_inputs_leak_taxonomy.md`: Highlighted the usage of the "Inputs" transport terminology inside the Domain boundary (`RawWaitInputs`, `DurationInputs`).

---
*PR created automatically by Jules for task [16319319132444480327](https://jules.google.com/task/16319319132444480327) started by @akitorahayashi*