### PR TITLE
Add observer events for test coverage gaps

### DIFF
--- a/.jules/exchange/events/untested_boolean_and_label_paths_cov.md
+++ b/.jules/exchange/events/untested_boolean_and_label_paths_cov.md
@@ -1,0 +1,33 @@
+---
+label: "tests"
+created_at: "2026-03-27"
+author_role: "cov"
+confidence: "high"
+---
+
+## Problem
+
+Some branches and execution paths related to user inputs are completely uncovered by tests, creating regression risks around core action configuration logic.
+
+## Goal
+
+Add tests to ensure `parseBooleanInput` and `normalizeLabel` are fully covered, reducing regression risks during configuration normalization.
+
+## Context
+
+Test coverage analysis shows that specific branches in `src/domain/wait-request.ts` are uncovered. For example, `parseBooleanInput`'s branch checking for truthy values (`'1'`, `'true'`, `'yes'`, `'on'`) and `normalizeLabel`'s branch checking for empty string and returning `undefined` or a non-empty string. These are simple logic branches but are essential to accurately ingest action parameters. Uncovered configuration parsing can cause broken GitHub actions.
+
+## Evidence
+
+- path: "src/domain/wait-request.ts"
+  loc: "37-39"
+  note: "Branch parsing truthy boolean tokens (like 'true', '1') is untested."
+
+- path: "src/domain/wait-request.ts"
+  loc: "53"
+  note: "The ternary operator `value.length === 0 ? undefined : value` in normalizeLabel is untested, leaving empty string checking unverified."
+
+## Change Scope
+
+- `src/domain/wait-request.ts`
+- `tests/domain/wait-request.test.ts`

--- a/.jules/exchange/events/untested_entrypoint_catch_cov.md
+++ b/.jules/exchange/events/untested_entrypoint_catch_cov.md
@@ -1,0 +1,28 @@
+---
+label: "tests"
+created_at: "2026-03-27"
+author_role: "cov"
+confidence: "high"
+---
+
+## Problem
+
+The main entry point exception handler is not covered by tests.
+
+## Goal
+
+Ensure the entry point handles top-level errors and correctly reports action failures, reducing the chance of swallowed errors on fatal crashes.
+
+## Context
+
+The main block executing the Action (`if (require.main === module) { run().catch(handleError) }`) does not get executed during standard tests because `require.main !== module` in vitest runner. While hard to test, this logic can be factored out or tested through child process execution to guarantee that uncaught exceptions correctly translate into action failures. Currently `DA:45,0` and `DA:46,0` in `src/index.ts`. While an intentional exclusion could be accepted, silently ignoring the entrypoint is an anti-pattern.
+
+## Evidence
+
+- path: "src/index.ts"
+  loc: "44-46"
+  note: "The top-level `run().catch(handleError)` is ignored by test runs."
+
+## Change Scope
+
+- `src/index.ts`


### PR DESCRIPTION
Added two event files documenting test coverage gaps in the project:
1. Untested branches in `src/domain/wait-request.ts` when parsing boolean inputs and normalizing labels.
2. Uncovered block in `src/index.ts` where the main execution catches exceptions.

These events follow the observer contract and provide actionable items for improving the project's test suite and controlling regression risks.

---
*PR created automatically by Jules for task [3594424643099780658](https://jules.google.com/task/3594424643099780658) started by @akitorahayashi*