### PR TITLE
Add data architecture observer events

### DIFF
--- a/.jules/exchange/events/cancellation_signal_modeling_data_arch.md
+++ b/.jules/exchange/events/cancellation_signal_modeling_data_arch.md
@@ -1,0 +1,37 @@
+---
+label: "refacts"
+created_at: "2026-03-27"
+author_role: "data_arch"
+confidence: "high"
+---
+
+## Problem
+
+Signal types (`'SIGINT' | 'SIGTERM'`) are hardcoded across multiple domain, adapter, and index layers as literal string types, creating scattered duplication. Error boundary handling throws exceptions into control flow instead of returning explicitly modeled results.
+
+## Goal
+
+Define a single source of truth for runtime signals (e.g., an enum or constant-type module). Move from using thrown errors (`WaitCancelledError`) for control flow to a union or Result-based approach for returning a cancellation state gracefully back to `index.ts`.
+
+## Context
+
+The core application flow uses `throw new WaitCancelledError(signal)` deeply inside an adapter (`cancellation-aware-delay`), bypassing the domain's return path. This forces the entrypoint (`index.ts`) to rely on an instance-of check instead of explicitly handling the return state from `executeWait`.
+
+## Evidence
+
+- path: "src/adapters/cancellation-aware-delay.ts"
+  loc: "4-12"
+  note: "`WaitCancelledError` is defined in an adapter layer and uses literal types for signals."
+- path: "src/index.ts"
+  loc: "16-20"
+  note: "Entrypoint relies on `instanceof WaitCancelledError` to catch an expected control flow (cancellation)."
+- path: "src/index.ts"
+  loc: "30-37"
+  note: "Duplicated literal union `'SIGINT' | 'SIGTERM'` inside `signalExitCode`."
+
+## Change Scope
+
+- `src/domain/cancellation-signal.ts` (new)
+- `src/adapters/cancellation-aware-delay.ts`
+- `src/index.ts`
+- `src/app/execute-wait/index.ts`

--- a/.jules/exchange/events/wait_request_validation_data_arch.md
+++ b/.jules/exchange/events/wait_request_validation_data_arch.md
@@ -1,0 +1,39 @@
+---
+label: "refacts"
+created_at: "2026-03-27"
+author_role: "data_arch"
+confidence: "high"
+---
+
+## Problem
+
+Data validation and normalization for input parameters are scattered across `WaitRequest` creation instead of being encapsulated at the boundary, and implicit error modeling is used instead of explicit result types. Types like `WaitRequest` allow invalid states if bypassed, and `RawWaitInputs` vs `WaitRequest` shows transport DTOs leaking into core domain logic. Also, `parseBooleanInput` and `resolveEffectiveSeconds` use panics/throws for validation.
+
+## Goal
+
+Ensure strong boundary sovereignty and representation of valid states only. Create a robust conversion boundary from raw string inputs to a valid domain model (`WaitRequest`). Validation should use explicit error modeling rather than throwing errors.
+
+## Context
+
+The system currently reads string inputs from GitHub Actions (`@actions/core`) in `src/action/read-inputs.ts` and maps them directly using `normalizeWaitRequest` in `src/domain/wait-request.ts`. The normalization functions (`parseBooleanInput`, `resolveEffectiveSeconds`) throw runtime errors for invalid inputs. This violates the principle of explicit error modeling (using result/either types instead of panics) and boundary sovereignty (transport concerns like `RawWaitInputs` are inside the `domain` folder).
+
+## Evidence
+
+- path: "src/domain/wait-request.ts"
+  loc: "12-17"
+  note: "`RawWaitInputs` is a transport DTO (stringly typed inputs from Action) leaking into the `domain` module."
+- path: "src/domain/wait-request.ts"
+  loc: "44-46"
+  note: "`parseBooleanInput` throws a runtime error instead of explicit error modeling."
+- path: "src/domain/duration.ts"
+  loc: "19-21"
+  note: "`parseNonNegativeInteger` throws a runtime error instead of explicit error modeling."
+- path: "src/action/read-inputs.ts"
+  loc: "4-11"
+  note: "Reads raw strings from action core and directly passes them to domain logic which may throw."
+
+## Change Scope
+
+- `src/domain/wait-request.ts`
+- `src/domain/duration.ts`
+- `src/action/read-inputs.ts`

--- a/.jules/exchange/events/wait_result_outputs_data_arch.md
+++ b/.jules/exchange/events/wait_result_outputs_data_arch.md
@@ -1,0 +1,32 @@
+---
+label: "refacts"
+created_at: "2026-03-27"
+author_role: "data_arch"
+confidence: "medium"
+---
+
+## Problem
+
+`WaitResult` acts as both the internal domain representation of a finished wait action and the transport/output layer interface, meaning its fields directly couple to GitHub Actions outputs without a formal transformation boundary.
+
+## Goal
+
+Separate the pure domain model of `WaitResult` from the `emitOutputs` layer. Create an explicit transformation step between the internal representation of what happened (e.g. `startedAt`, `endedAt`, `duration`, `status`) and what gets emitted to `@actions/core`.
+
+## Context
+
+`WaitResult` holds `waited` (boolean) and `effectiveSeconds` (number) which happens to be exactly what gets emitted as outputs. It does not carry meaningful domain information about the action state, simply transport DTO fields.
+
+## Evidence
+
+- path: "src/domain/wait-result.ts"
+  loc: "1-4"
+  note: "Defines output fields directly, strongly resembling an Actions output format rather than capturing meaningful domain state."
+- path: "src/action/emit-outputs.ts"
+  loc: "4-7"
+  note: "`emitOutputs` relies on `WaitResult` directly matching output parameter names in meaning."
+
+## Change Scope
+
+- `src/domain/wait-result.ts`
+- `src/action/emit-outputs.ts`


### PR DESCRIPTION
I have completed the task of emitting event files as a data architect. I have created 3 event files in the `.jules/exchange/events/` directory detailing the current state of data validation, explicit error modeling, boundary separation, and signal modeling.

The 3 files are:
- `wait_request_validation_data_arch.md`
- `wait_result_outputs_data_arch.md`
- `cancellation_signal_modeling_data_arch.md`

All files adhere to the `.jules/schemas/event.md` structure and role constraints. Tests and linting also pass successfully.

---
*PR created automatically by Jules for task [10117424168496648916](https://jules.google.com/task/10117424168496648916) started by @akitorahayashi*