### PR TITLE
docs: emit typescripter observer events

### DIFF
--- a/.jules/exchange/events/catch_block_coerces_error_to_any_typescripter.md
+++ b/.jules/exchange/events/catch_block_coerces_error_to_any_typescripter.md
@@ -1,0 +1,28 @@
+---
+label: "bugs"
+created_at: "2026-03-27"
+author_role: "typescripter"
+confidence: "high"
+---
+
+## Problem
+
+The action boundary error handler relies on a string coercion (`String(error)`) for unknown errors, swallowing the potential structure of thrown non-Error objects (like library response bodies).
+
+## Goal
+
+Improve boundary type integrity by implementing strict failure semantics at the edge for unknown errors, ensuring unhandled rejections or throws are safely structured before logging.
+
+## Context
+
+In `src/index.ts`, the `handleError(error: unknown)` function acts as the final boundary before GitHub Actions process exit. If the error is not a `WaitCancelledError` and not an `Error` (e.g. if a library throws an object or primitive), the error is forcefully stringified (`core.setFailed(String(error))`), which loses context if it is an object literal and provides poor operational transparency.
+
+## Evidence
+
+- path: "src/index.ts"
+  loc: "line 31"
+  note: "Fallback error coercion stringifies `unknown` rather than checking if it has a `message` property or handling it safely."
+
+## Change Scope
+
+- `src/index.ts`

--- a/.jules/exchange/events/switch_exhaustive_missing_typescripter.md
+++ b/.jules/exchange/events/switch_exhaustive_missing_typescripter.md
@@ -1,0 +1,28 @@
+---
+label: "bugs"
+created_at: "2026-03-27"
+author_role: "typescripter"
+confidence: "high"
+---
+
+## Problem
+
+The `signalExitCode` switch statement relies on TypeScript's default checks without an explicit `never` assertion, so expanding the union type won't trigger a runtime exhaustiveness error if the compiler checks are loose or ignored.
+
+## Goal
+
+Ensure state handling exhaustiveness by adding an explicit `never` check (or an `assertNever` helper) in the default case for the `signal` union.
+
+## Context
+
+In `src/index.ts`, `signalExitCode(signal: 'SIGINT' | 'SIGTERM')` correctly handles two string literals. However, if another signal (like `'SIGHUP'`) is later added to the union, TypeScript would only warn if `strictNullChecks` or `noImplicitReturns` forces it. A true exhaustiveness check (`const _: never = signal;`) explicitly prevents the invalid state at compile time and is a safer best practice for state unions.
+
+## Evidence
+
+- path: "src/index.ts"
+  loc: "line 36-41"
+  note: "Switch lacks an explicit default `never` case, making it potentially non-exhaustive if the type signature is expanded."
+
+## Change Scope
+
+- `src/index.ts`

--- a/.jules/exchange/events/unvalidated_record_boundary_typescripter.md
+++ b/.jules/exchange/events/unvalidated_record_boundary_typescripter.md
@@ -1,0 +1,32 @@
+---
+label: "bugs"
+created_at: "2026-03-27"
+author_role: "typescripter"
+confidence: "medium"
+---
+
+## Problem
+
+`RawWaitInputs` assumes specific string types are present without true boundary validation on external environment data (GitHub inputs), resulting in `normalizeWaitRequest` accepting loosely parsed primitives and possibly masking type errors at the API edge.
+
+## Goal
+
+Strengthen boundary type integrity by fully parsing GitHub input strings from `unknown` into `WaitRequest` at the read step, removing the intermediate loosely-typed `RawWaitInputs` interface that merely delegates parsing deeper into the core.
+
+## Context
+
+In `src/action/read-inputs.ts` and `src/domain/wait-request.ts`, `readInputs()` generates `RawWaitInputs` with string or undefined values which are then transformed by `normalizeWaitRequest`. The external system (GitHub) only provides strings; these should be parsed immediately to domain types (`number`, `boolean`) at the boundary rather than passing around `string | undefined` within an interface that implies the inputs have entered the application domain.
+
+## Evidence
+
+- path: "src/domain/wait-request.ts"
+  loc: "line 9"
+  note: "`RawWaitInputs` uses primitive strings, pushing external data validation deeper into the app instead of validating at the entry edge."
+- path: "src/action/read-inputs.ts"
+  loc: "line 5"
+  note: "`readInputs` returns domain type `WaitRequest` but passes strings to `normalizeWaitRequest`, mixing boundary parsing with domain instantiation."
+
+## Change Scope
+
+- `src/domain/wait-request.ts`
+- `src/action/read-inputs.ts`


### PR DESCRIPTION
Emitted observer events for type integrity, state modeling and failure semantics improvements.

---
*PR created automatically by Jules for task [18100187913755628788](https://jules.google.com/task/18100187913755628788) started by @akitorahayashi*