### PR TITLE
Dispatcher Triage of Requirements

### DIFF
--- a/.jules/exchange/events/gitkeep.md
+++ b/.jules/exchange/events/gitkeep.md
@@ -1,0 +1,4 @@
+---
+label: "refacts"
+implementation_ready: false
+---

--- a/.jules/exchange/plans/gitkeep.md
+++ b/.jules/exchange/plans/gitkeep.md
@@ -1,0 +1,4 @@
+---
+label: "refacts"
+implementation_ready: false
+---

--- a/.jules/exchange/proposals/gitkeep.md
+++ b/.jules/exchange/proposals/gitkeep.md
@@ -1,0 +1,4 @@
+---
+label: "refacts"
+implementation_ready: false
+---

--- a/.jules/exchange/requirements/architecture_dependency_drift.md
+++ b/.jules/exchange/requirements/architecture_dependency_drift.md
@@ -1,0 +1,45 @@
+---
+label: "docs"
+implementation_ready: true
+---
+
+## Goal
+
+Correct documentation regarding dependency direction to accurately reflect the decoupled architecture.
+
+## Problem
+
+`docs/architecture.md` states `app -> adapters`, but runtime composition dynamically injects dependencies in `index.ts`.
+
+## Context
+
+The documentation should accurately reflect the decoupled architecture of the system. Currently, `docs/architecture.md` states `app -> adapters`. But the implementation injects the delay dependency into `executeWait` from `src/index.ts`, meaning `app -> none` (or only domain), and `index -> adapters`.
+
+## Evidence
+
+- source_event: "architecture_dependency_drift_consistency.md"
+  path: "docs/architecture.md"
+  loc: "14"
+  note: "Claims `app -> adapters` dependency direction."
+
+- source_event: "architecture_dependency_drift_consistency.md"
+  path: "src/app/execute-wait/index.ts"
+  loc: "1-5"
+  note: "Shows `executeWait` importing only from `domain` and relying on `ExecuteWaitDependencies` interface."
+
+- source_event: "architecture_dependency_drift_consistency.md"
+  path: "src/index.ts"
+  loc: "5-15"
+  note: "Shows `index.ts` importing from `adapters` and passing `cancellationAwareDelay` into `executeWait`."
+
+## Change Scope
+
+- `docs/architecture.md`
+
+## Constraints
+
+- The documentation update must reflect the actual decoupled dependency structure.
+
+## Acceptance Criteria
+
+- `docs/architecture.md` correctly models the dependency injection architecture (`app -> none`, `index -> adapters`).

--- a/.jules/exchange/requirements/cancellation_signal_modeling.md
+++ b/.jules/exchange/requirements/cancellation_signal_modeling.md
@@ -1,0 +1,56 @@
+---
+label: "refacts"
+implementation_ready: false
+---
+
+## Goal
+
+Centralize cancellation signal definitions and ensure exhaustive handling while returning explicit state instead of throwing cancellation errors.
+
+## Problem
+
+Signal definitions are scattered literals, and cancellation flow relies on throwing/catching `WaitCancelledError` deep in adapters. Furthermore, the `signalExitCode` switch lacks exhaustiveness checks for the signal union.
+
+## Context
+
+The core application flow uses `throw new WaitCancelledError(signal)` deeply inside an adapter (`cancellation-aware-delay`), bypassing the domain's return path. This forces the entrypoint (`index.ts`) to rely on an instance-of check instead of explicitly handling the return state from `executeWait`. In `src/index.ts`, `signalExitCode(signal: 'SIGINT' | 'SIGTERM')` correctly handles two string literals. However, if another signal (like `'SIGHUP'`) is later added to the union, TypeScript would only warn if `strictNullChecks` or `noImplicitReturns` forces it. A true exhaustiveness check (`const _: never = signal;`) explicitly prevents the invalid state at compile time and is a safer best practice for state unions.
+
+## Evidence
+
+- source_event: "cancellation_signal_modeling_data_arch.md"
+  path: "src/adapters/cancellation-aware-delay.ts"
+  loc: "4-12"
+  note: "`WaitCancelledError` is defined in an adapter layer and uses literal types for signals, throwing for control flow."
+
+- source_event: "cancellation_signal_modeling_data_arch.md"
+  path: "src/index.ts"
+  loc: "22-26"
+  note: "Entrypoint relies on `instanceof WaitCancelledError` to catch an expected control flow (cancellation)."
+
+- source_event: "cancellation_signal_modeling_data_arch.md"
+  path: "src/index.ts"
+  loc: "36-41"
+  note: "Duplicated literal union `'SIGINT' | 'SIGTERM'` inside `signalExitCode`."
+
+- source_event: "switch_exhaustive_missing_typescripter.md"
+  path: "src/index.ts"
+  loc: "line 36-41"
+  note: "Switch lacks an explicit default `never` case, making it potentially non-exhaustive if the type signature is expanded."
+
+## Change Scope
+
+- `src/domain/cancellation-signal.ts`
+- `src/adapters/cancellation-aware-delay.ts`
+- `src/index.ts`
+- `src/app/execute-wait/index.ts`
+
+## Constraints
+
+- Define a single source of truth for runtime signals.
+- Avoid throwing for expected control flow like cancellation.
+
+## Acceptance Criteria
+
+- Signals are defined in a centralized domain type.
+- `cancellationAwareDelay` handles cancellation using return state or explicit Results.
+- `signalExitCode` has an exhaustive `never` check for unrecognized signals.

--- a/.jules/exchange/requirements/entrypoint_error_handling.md
+++ b/.jules/exchange/requirements/entrypoint_error_handling.md
@@ -1,0 +1,43 @@
+---
+label: "bugs"
+implementation_ready: false
+---
+
+## Goal
+
+Ensure safe error coercion at the entrypoint and verify top-level error handling logic.
+
+## Problem
+
+The top-level `run().catch(handleError)` is untested and `handleError(error: unknown)` aggressively stringifies unknown errors, losing context. This can swallow the structure of non-Error objects thrown at runtime.
+
+## Context
+
+In `src/index.ts`, the `handleError(error: unknown)` function acts as the final boundary before GitHub Actions process exit. If the error is not a `WaitCancelledError` and not an `Error` (e.g. if a library throws an object or primitive), the error is forcefully stringified (`core.setFailed(String(error))`), which loses context if it is an object literal and provides poor operational transparency. Additionally, the main block executing the Action (`if (require.main === module) { run().catch(handleError) }`) does not get executed during standard tests because `require.main !== module` in vitest runner. While hard to test, this logic can be factored out or tested through child process execution to guarantee that uncaught exceptions correctly translate into action failures.
+
+## Evidence
+
+- source_event: "catch_block_coerces_error_to_any_typescripter.md"
+  path: "src/index.ts"
+  loc: "33"
+  note: "Fallback error coercion stringifies `unknown` rather than checking if it has a `message` property or handling it safely."
+
+- source_event: "untested_entrypoint_catch_cov.md"
+  path: "src/index.ts"
+  loc: "44-46"
+  note: "The top-level `run().catch(handleError)` is ignored by test runs."
+
+## Change Scope
+
+- `src/index.ts`
+- `tests/index.test.ts`
+
+## Constraints
+
+- Safely handle non-Error objects thrown at the top level.
+- Must cover entrypoint catch block in tests.
+
+## Acceptance Criteria
+
+- Uncaught errors are correctly coerced or logged without losing structure if they aren't standard `Error` objects.
+- `run().catch(handleError)` path has test coverage.

--- a/.jules/exchange/requirements/gitkeep.md
+++ b/.jules/exchange/requirements/gitkeep.md
@@ -1,0 +1,4 @@
+---
+label: "refacts"
+implementation_ready: false
+---

--- a/.jules/exchange/requirements/input_boundary_validation.md
+++ b/.jules/exchange/requirements/input_boundary_validation.md
@@ -1,0 +1,87 @@
+---
+label: "refacts"
+implementation_ready: false
+---
+
+## Goal
+
+Strengthen input boundary parsing and validation without throwing errors, and decouple domain structures from transport terminology.
+
+## Problem
+
+Input validation is scattered and uses transport-specific naming ('Inputs') in the domain. Instead of using explicit result types, validation throws panics. Additionally, boolean and label parsing paths lack test coverage, masking boundary errors.
+
+## Context
+
+The system currently reads string inputs from GitHub Actions (`@actions/core`) in `src/action/read-inputs.ts` and maps them directly using `normalizeWaitRequest` in `src/domain/wait-request.ts`. The normalization functions (`parseBooleanInput`, `resolveEffectiveSeconds`) throw runtime errors for invalid inputs. This violates the principle of explicit error modeling (using result/either types instead of panics) and boundary sovereignty (transport concerns like `RawWaitInputs` are inside the `domain` folder). In `src/action/read-inputs.ts` and `src/domain/wait-request.ts`, `readInputs()` generates `RawWaitInputs` with string or undefined values which are then transformed by `normalizeWaitRequest`. The external system (GitHub) only provides strings; these should be parsed immediately to domain types (`number`, `boolean`) at the boundary rather than passing around `string | undefined` within an interface that implies the inputs have entered the application domain. The domain files `wait-request.ts` and `duration.ts` define types `RawWaitInputs` and `DurationInputs`. This implies the domain is aware of how it is invoked (via GitHub Action inputs). The Domain should model the problem space independently. A more domain-appropriate name for unparsed, transport-agnostic data would be something like `RawWaitRequest` and `RawDuration` or `UnvalidatedDuration`. Test coverage analysis shows that specific branches in `src/domain/wait-request.ts` are uncovered. For example, `parseBooleanInput`'s branch checking for truthy values (`'1'`, `'true'`, `'yes'`, `'on'`) and `normalizeLabel`'s branch checking for empty string and returning `undefined` or a non-empty string.
+
+## Evidence
+
+- source_event: "domain_inputs_leak_taxonomy.md"
+  path: "src/domain/wait-request.ts"
+  loc: "9-14"
+  note: "`RawWaitInputs` uses the word 'Inputs', leaking the action input concept into the Domain layer."
+
+- source_event: "unvalidated_record_boundary_typescripter.md"
+  path: "src/action/read-inputs.ts"
+  loc: "line 5"
+  note: "`readInputs` returns domain type `WaitRequest` but passes strings to `normalizeWaitRequest`, mixing boundary parsing with domain instantiation."
+
+- source_event: "wait_request_validation_data_arch.md"
+  path: "src/domain/wait-request.ts"
+  loc: "47"
+  note: "`parseBooleanInput` throws a runtime error instead of explicit error modeling."
+
+- source_event: "wait_request_validation_data_arch.md"
+  path: "src/domain/duration.ts"
+  loc: "19-21"
+  note: "`parseNonNegativeInteger` throws a runtime error instead of explicit error modeling."
+
+- source_event: "wait_request_validation_data_arch.md"
+  path: "src/action/read-inputs.ts"
+  loc: "4-11"
+  note: "Reads raw strings from action core and directly passes them to domain logic which may throw."
+
+- source_event: "domain_inputs_leak_taxonomy.md"
+  path: "src/domain/duration.ts"
+  loc: "line 1"
+  note: "`DurationInputs` uses the word 'Inputs', unnecessarily associating raw temporal duration values with the action transport mechanism."
+
+- source_event: "unvalidated_record_boundary_typescripter.md"
+  path: "src/domain/wait-request.ts"
+  loc: "9-14"
+  note: "`RawWaitInputs` uses primitive strings, pushing external data validation deeper into the app instead of validating at the entry edge."
+
+- source_event: "wait_request_validation_data_arch.md"
+  path: "src/domain/wait-request.ts"
+  loc: "12-17"
+  note: "`RawWaitInputs` is a transport DTO (stringly typed inputs from Action) leaking into the `domain` module."
+
+- source_event: "untested_boolean_and_label_paths_cov.md"
+  path: "src/domain/wait-request.ts"
+  loc: "37-39"
+  note: "Branch parsing truthy boolean tokens (like 'true', '1') is untested."
+
+- source_event: "untested_boolean_and_label_paths_cov.md"
+  path: "src/domain/wait-request.ts"
+  loc: "55"
+  note: "The ternary operator `value.length === 0 ? undefined : value` in normalizeLabel is untested, leaving empty string checking unverified."
+
+## Change Scope
+
+- `src/domain/wait-request.ts`
+- `src/domain/duration.ts`
+- `src/action/read-inputs.ts`
+- `tests/domain/wait-request.test.ts`
+
+## Constraints
+
+- Validation should use explicit error modeling rather than throwing errors.
+- External raw values must be parsed at the edge into domain models without intermediate transport-coupled domain types.
+
+## Acceptance Criteria
+
+- Domain inputs are renamed to decouple from transport terminology (e.g., `RawWaitRequest` instead of `RawWaitInputs`).
+- `parseBooleanInput` and `resolveEffectiveSeconds` return error objects/Results rather than throwing.
+- Tests cover `parseBooleanInput` and `normalizeLabel` fully.
+- Boundary inputs are converted from `unknown`/`string` directly to domain types at the edge.

--- a/.jules/exchange/requirements/test_mock_coupling_reduction.md
+++ b/.jules/exchange/requirements/test_mock_coupling_reduction.md
@@ -1,0 +1,52 @@
+---
+label: "tests"
+implementation_ready: false
+---
+
+## Goal
+
+Refactor tests to validate observable outcomes rather than tightly coupling to implementation details via mocks.
+
+## Problem
+
+Both the adapter tests for `cancellation-aware-delay` and the integration tests for `index.ts` are overly brittle due to deep mocking of internal modules, timers, and the Node process object.
+
+## Context
+
+Tests should be resilient to internal refactoring. Because `cancellation-aware-delay.test.ts` heavily spies and mocks `process` and `setTimeout`, any change to the underlying timer mechanism (like adopting `timers/promises` or changing how chunks are processed) will break the test, causing brittleness and high maintenance costs. The main action file (`index.ts`) orchestrates the overall flow. Tests that mock out all internal dependencies provide little value in verifying that the integrated components actually work together correctly. This makes the test brittle during refactors when module boundaries change (e.g., if logic is moved between `readInputs` and `executeWait`).
+
+## Evidence
+
+- source_event: "cancellation_delay_mock_coupling_qa.md"
+  path: "tests/adapters/cancellation-aware-delay.test.ts"
+  loc: "captureSignalHandlers"
+  note: "Mocks `process.on` and `process.off` directly instead of observing external effects."
+
+- source_event: "cancellation_delay_mock_coupling_qa.md"
+  path: "tests/adapters/cancellation-aware-delay.test.ts"
+  loc: "setTimeoutSpy"
+  note: "Spies on `global.setTimeout` directly instead of relying solely on `vi.useFakeTimers()` external behavior control."
+
+- source_event: "index_mock_coupling_qa.md"
+  path: "tests/index.test.ts"
+  loc: "7-18"
+  note: "Mocks internal components like `readInputs`, `executeWait`, and `emitOutputs` rather than testing the real coordination."
+
+- source_event: "index_mock_coupling_qa.md"
+  path: "tests/index.test.ts"
+  loc: "44-49"
+  note: "Relies on verifying that specific mocked functions were called with specific arguments, rather than validating external state changes or outcomes."
+
+## Change Scope
+
+- `tests/adapters/cancellation-aware-delay.test.ts`
+- `tests/index.test.ts`
+
+## Constraints
+
+- Focus tests on observable inputs, outputs, and behaviors.
+
+## Acceptance Criteria
+
+- `index.test.ts` acts as a proper boundary or seam test without full internal mocking.
+- `cancellation-aware-delay.test.ts` avoids mocking internal timer/process mechanics where external behavioral assertions suffice.

--- a/.jules/exchange/requirements/wait_result_outputs_separation.md
+++ b/.jules/exchange/requirements/wait_result_outputs_separation.md
@@ -1,0 +1,42 @@
+---
+label: "refacts"
+implementation_ready: false
+---
+
+## Goal
+
+Separate pure domain model for action results from transport output schema.
+
+## Problem
+
+`WaitResult` acts as both the internal domain representation and the transport output layer interface, directly coupling its fields to GitHub Actions outputs.
+
+## Context
+
+`WaitResult` holds `waited` (boolean) and `effectiveSeconds` (number) which happens to be exactly what gets emitted as outputs. It does not carry meaningful domain information about the action state, simply transport DTO fields.
+
+## Evidence
+
+- source_event: "wait_result_outputs_data_arch.md"
+  path: "src/domain/wait-result.ts"
+  loc: "1-4"
+  note: "Defines output fields directly, strongly resembling an Actions output format rather than capturing meaningful domain state."
+
+- source_event: "wait_result_outputs_data_arch.md"
+  path: "src/action/emit-outputs.ts"
+  loc: "4-7"
+  note: "`emitOutputs` relies on `WaitResult` directly matching output parameter names in meaning."
+
+## Change Scope
+
+- `src/domain/wait-result.ts`
+- `src/action/emit-outputs.ts`
+
+## Constraints
+
+- Output DTOs should not be the same type as domain results.
+
+## Acceptance Criteria
+
+- `WaitResult` represents a pure domain model of action completion.
+- `emitOutputs` transforms the pure domain model into the required GitHub Actions outputs.

--- a/.jules/exchange/requirements/wait_vs_delay_taxonomy.md
+++ b/.jules/exchange/requirements/wait_vs_delay_taxonomy.md
@@ -1,0 +1,45 @@
+---
+label: "refacts"
+implementation_ready: false
+---
+
+## Goal
+
+Establish clear, consistent taxonomy separating 'Wait' (domain concept) from 'Delay' (technical mechanism).
+
+## Problem
+
+Synonym collision conflates 'Wait' and 'Delay'. `ExecuteWaitDependencies` injects `delay` and `cancellationAwareDelay` throws `WaitCancelledError`, mixing the concepts in the same logical layer.
+
+## Context
+
+The repository represents a GitHub Action designed to "wait" for a duration. The domain speaks of `WaitRequest` and `WaitResult`, but the application layer (`executeWait`) relies on an injected `ExecuteWaitDependencies.delay` function. Furthermore, the adapter `cancellationAwareDelay` throws a `WaitCancelledError`, mixing the two concepts in a single file. This violates the "One Concept, One Preferred Term" principle.
+
+## Evidence
+
+- source_event: "wait_vs_delay_taxonomy.md"
+  path: "src/app/execute-wait/execute-wait-dependencies.ts"
+  loc: "line 2"
+  note: "Domain application boundary `ExecuteWaitDependencies` uses `delay: (seconds: number) => Promise<void>` instead of `wait`."
+
+- source_event: "wait_vs_delay_taxonomy.md"
+  path: "src/adapters/cancellation-aware-delay.ts"
+  loc: "lines 4-13, 17"
+  note: "The function is named `cancellationAwareDelay` but it explicitly throws `WaitCancelledError`."
+
+## Change Scope
+
+- `src/app/execute-wait/execute-wait-dependencies.ts`
+- `src/app/execute-wait/index.ts`
+- `src/adapters/cancellation-aware-delay.ts`
+- `src/index.ts`
+
+## Constraints
+
+- 'Wait' must represent the business suspension concept.
+- 'Delay' must be reserved exclusively for the low-level timer mechanism.
+
+## Acceptance Criteria
+
+- `ExecuteWaitDependencies` uses domain-appropriate terminology instead of 'delay'.
+- Domain and Adapter layers strictly separate 'Wait' and 'Delay' nomenclature.


### PR DESCRIPTION
Triage requirements in `.jules/exchange/requirements`:
- Checked each requirement against the repository truth.
- Marked `architecture_dependency_drift.md` as `implementation_ready` because it is trivially small (< 80 lines).
- Adjusted line numbers across requirement evidence blocks to be consistent with the actual source code.
- All other requirements correctly remain `implementation_ready: false` as they involve complex cross-cutting domain refactors or complicated testing enhancements.

---
*PR created automatically by Jules for task [1483419345932764121](https://jules.google.com/task/1483419345932764121) started by @akitorahayashi*