### PR TITLE
Emit data architecture events

### DIFF
--- a/.jules/exchange/events/implicit_validation_exceptions_data_arch.md
+++ b/.jules/exchange/events/implicit_validation_exceptions_data_arch.md
@@ -1,0 +1,39 @@
+---
+label: "refacts"
+created_at: "2026-03-29"
+author_role: "data_arch"
+confidence: "high"
+---
+
+## Problem
+
+Implicit validation via thrown errors instead of explicit error modeling within domain boundaries.
+
+## Goal
+
+Refactor the validation logic inside `src/domain/wait-request.ts` and `src/domain/duration.ts` to return explicit results (`Result<T, E>`) mapping valid/invalid states, instead of throwing errors globally.
+
+## Context
+
+According to the data architecture anti-patterns "Implicit validation via panics/unwraps instead of explicit error modeling", validation logic should be represented by explicitly modeling valid and invalid states within type signatures. However, both `parseBooleanInput` and `parseNonNegativeNumber` enforce assertions by using generic `throw new Error(...)`, relying on caller try-catch rather than explicit Result structures. The domain should represent validation rules using Result return types and encode invariants clearly at transport boundaries (e.g. read-inputs).
+
+## Evidence
+
+- path: "src/domain/wait-request.ts"
+  loc: "line 43-44"
+  note: "`parseBooleanInput` implicitly enforces validation rules by throwing a generic Error (`throw new Error(\`Input '\${name}' must be a recognized boolean value.\`)`)."
+
+- path: "src/domain/duration.ts"
+  loc: "line 29-30"
+  note: "`parseNonNegativeNumber` implicitly fails on an empty string by throwing an Error instead of returning a typed validation result."
+
+- path: "src/domain/duration.ts"
+  loc: "line 34-35"
+  note: "`parseNonNegativeNumber` implicitly fails on unparseable or negative values by throwing an Error instead of returning a typed validation result."
+
+## Change Scope
+
+- `src/domain/wait-request.ts`
+- `src/domain/duration.ts`
+- `src/action/read-inputs.ts`
+- `src/index.ts`

--- a/.jules/exchange/events/transport_dto_leak_data_arch.md
+++ b/.jules/exchange/events/transport_dto_leak_data_arch.md
@@ -1,0 +1,38 @@
+---
+label: "refacts"
+created_at: "2026-03-29"
+author_role: "data_arch"
+confidence: "high"
+---
+
+## Problem
+
+Transport DTOs and string parsing logic are located inside the core domain model instead of at the entry boundary.
+
+## Goal
+
+Decouple transport/UI string inputs from the pure domain model by moving `DurationInputs` and `RawWaitInputs` to the adapters or action layer. The domain `WaitRequest` and `Duration` should only deal with validated, strongly-typed values (e.g., numbers, booleans) instead of handling parsing logic.
+
+## Context
+
+According to the data architecture first principles on "Boundary Sovereignty", domain models should be kept independent of transport/UI/runtime concerns. In the codebase, `src/domain/wait-request.ts` exposes `RawWaitInputs` consisting entirely of optional strings, which are transport-layer types (e.g. GitHub Action inputs). The same applies to `DurationInputs` in `src/domain/duration.ts`. The domain is thus coupled to string parsing logic such as `'1', 'true', 'yes', 'on'`, preventing it from representing valid states only and enforcing invariants strictly at the boundaries.
+
+## Evidence
+
+- path: "src/domain/wait-request.ts"
+  loc: "line 10-15"
+  note: "`RawWaitInputs` defines string inputs which are typical of a transport layer (Action inputs), leaking into the domain module."
+
+- path: "src/domain/wait-request.ts"
+  loc: "line 29-45"
+  note: "`parseBooleanInput` handles string values parsing logic (e.g., `'1', 'true', 'yes', 'on'`), which belongs to a transport/action adapter rather than core domain."
+
+- path: "src/domain/duration.ts"
+  loc: "line 1-4"
+  note: "`DurationInputs` represents string inputs instead of a strongly-typed duration model, indicating boundary leakage."
+
+## Change Scope
+
+- `src/domain/wait-request.ts`
+- `src/domain/duration.ts`
+- `src/action/read-inputs.ts`


### PR DESCRIPTION
Adds event files observing transport DTO leakage into domain boundaries and implicit exception validation.

---
*PR created automatically by Jules for task [3871970741253985015](https://jules.google.com/task/3871970741253985015) started by @akitorahayashi*