### PR TITLE
docs: add qa observer findings for tests

### DIFF
--- a/.jules/exchange/events/action_metadata_multiple_concerns_qa.md
+++ b/.jules/exchange/events/action_metadata_multiple_concerns_qa.md
@@ -1,0 +1,28 @@
+---
+label: "tests"
+created_at: "2026-03-29"
+author_role: "qa"
+confidence: "high"
+---
+
+## Problem
+
+The test `action-metadata.test.ts` violates the anti-pattern "Single tests asserting multiple unrelated concerns". It bundles the verification of the Node environment, entry points, inputs configuration, and outputs specification into one ambiguous test.
+
+## Goal
+
+To separate these unrelated assertions into distinct, well-isolated tests so that a failure in one area (like input changes) doesn't obscure the status of others (like environment configuration).
+
+## Context
+
+Testing unrelated concerns in a single block leads to ambiguous failures, increasing recovery cost and time-to-fix. If one assertion fails, the execution stops and hides the validity of subsequent assertions, requiring multiple cycles to ensure everything works correctly.
+
+## Evidence
+
+- path: "tests/action/action-metadata.test.ts"
+  loc: "22-32"
+  note: "This single `it` block contains 8 assertions covering multiple distinct, unrelated concerns: runs structure, inputs structure, and outputs structure."
+
+## Change Scope
+
+- `tests/action/action-metadata.test.ts`

--- a/.jules/exchange/events/delay_implementation_coupling_qa.md
+++ b/.jules/exchange/events/delay_implementation_coupling_qa.md
@@ -1,0 +1,31 @@
+---
+label: "tests"
+created_at: "2026-03-29"
+author_role: "qa"
+confidence: "high"
+---
+
+## Problem
+
+The test `cancellation-aware-delay.test.ts` violates the anti-pattern "Over-coupling tests to private implementation details". Specifically, it spies on `setTimeout` to extract a callback representing `scheduleNextChunk` and then manually executes it to simulate an edge case.
+
+## Goal
+
+Refactor the tests so they exercise externally observable behavior and do not break if the internal mechanism of fulfilling the delay changes from `setTimeout` to an alternative implementation.
+
+## Context
+
+By stubbing the internal logic with `vi.spyOn(global, 'setTimeout')` and extracting internal functions like `scheduleNextChunk`, the test is bound intimately to the component's internal state. This creates highly brittle tests that fail on refactoring, and fail to validate true, externally observable behavior, defeating the purpose of unit testing.
+
+## Evidence
+
+- path: "tests/adapters/cancellation-aware-delay.test.ts"
+  loc: "204-209"
+  note: "Intercepts the callback provided to `setTimeout` manually capturing a private component function `scheduleNextChunk`."
+- path: "tests/adapters/cancellation-aware-delay.test.ts"
+  loc: "223"
+  note: "Arbitrarily executing the extracted internal function to stimulate a state outside the ordinary control flow."
+
+## Change Scope
+
+- `tests/adapters/cancellation-aware-delay.test.ts`

--- a/.jules/exchange/events/wait_request_missing_properties_qa.md
+++ b/.jules/exchange/events/wait_request_missing_properties_qa.md
@@ -1,0 +1,31 @@
+---
+label: "tests"
+created_at: "2026-03-29"
+author_role: "qa"
+confidence: "high"
+---
+
+## Problem
+
+The test file `wait-request.test.ts` violates the "Missing properties" principle. It explicitly checks for the negative test case (when `enabled` is mapped to false, or is unparsable), but it completely misses validation for the truthy mapping cases like "true", "yes", "on", or "1". Additionally, the integration and mapping logic for assigning duration components to `effectiveSeconds` entirely lacks verification in this boundary component.
+
+## Goal
+
+Ensure comprehensive coverage by adding representative test cases for truthy `enabled` variations, and verifying the expected propagation of `minutes` and `seconds` via `resolveEffectiveSeconds`.
+
+## Context
+
+Because tests for these properties are entirely absent, a regression might occur mapping `enabled: "yes"` to `true` or failing to map time components correctly from raw inputs. A change in those areas would be a silent regression. Tests should thoroughly cover the domain mapping boundaries to guarantee the component properly delegates and structures requests correctly.
+
+## Evidence
+
+- path: "tests/domain/wait-request.test.ts"
+  loc: "5-22"
+  note: "Only missing, negative, and invalid boolean values are tested; truthy logic is absent."
+- path: "tests/domain/wait-request.test.ts"
+  loc: "5-22"
+  note: "There is no test coverage for mapping the duration components (`minutes` or `seconds`) to `effectiveSeconds` through this adapter mapping function."
+
+## Change Scope
+
+- `tests/domain/wait-request.test.ts`


### PR DESCRIPTION
This commit adds three event files in `.jules/exchange/events/` documenting QA findings regarding test structure and quality:
1. `action_metadata_multiple_concerns_qa.md`: Identifies a single test asserting multiple unrelated concerns in `action-metadata.test.ts`.
2. `delay_implementation_coupling_qa.md`: Identifies tests over-coupling to private implementation details by intercepting `setTimeout` in `cancellation-aware-delay.test.ts`.
3. `wait_request_missing_properties_qa.md`: Identifies missing property coverage for truthy boolean parsing and duration mapping in `wait-request.test.ts`.

---
*PR created automatically by Jules for task [4442821195584618550](https://jules.google.com/task/4442821195584618550) started by @akitorahayashi*