### PR TITLE
docs(typescripter): emit observer events for TypeScript boundaries and state modeling

### DIFF
--- a/.jules/exchange/events/duration_inputs_invalid_state_typescripter.md
+++ b/.jules/exchange/events/duration_inputs_invalid_state_typescripter.md
@@ -1,0 +1,32 @@
+---
+label: "refacts"
+created_at: "2024-03-29"
+author_role: "typescripter"
+confidence: "high"
+---
+
+## Problem
+
+The `DurationInputs` interface models state as an object containing optional `minutes` and `seconds` string properties. This loosely typed design permits an invalid state where both properties are defined simultaneously, which is logically inconsistent for an either/or input configuration. `resolveEffectiveSeconds` handles this ambiguously by silently prioritizing `seconds` over `minutes` without informing the user that `minutes` was ignored.
+
+## Goal
+
+Model the duration input state explicitly using a discriminated union so that only valid combinations (either `minutes` or `seconds`, or neither) can be represented by the type system. In `resolveEffectiveSeconds`, remove the silent fallback to enforce deterministic and explicit failure semantics or validation if invalid combinations are somehow encountered.
+
+## Context
+
+Using loosely defined optional properties to represent mutually exclusive states leads to type confusion and "impossible" states being technically representable. Silent fallbacks at runtime mask misconfigurations, leading to confusing behavior. Refactoring to a discriminated union enforces correct usage at compile time, aligning with "make invalid states unrepresentable" and ensuring failure semantics are explicit.
+
+## Evidence
+
+- path: "src/domain/duration.ts"
+  loc: "1-4"
+  note: "`DurationInputs` allows an object where both `minutes` and `seconds` are defined."
+- path: "src/domain/duration.ts"
+  loc: "9-15"
+  note: "`resolveEffectiveSeconds` silently handles the invalid state by falling back to `seconds` when both are defined."
+
+## Change Scope
+
+- `src/domain/duration.ts`
+- `src/domain/wait-request.ts`

--- a/.jules/exchange/events/missing_never_check_typescripter.md
+++ b/.jules/exchange/events/missing_never_check_typescripter.md
@@ -1,0 +1,28 @@
+---
+label: "refacts"
+created_at: "2024-03-29"
+author_role: "typescripter"
+confidence: "high"
+---
+
+## Problem
+
+The `signalExitCode` function in `src/index.ts` relies on the function return type enforcing that the `switch` block returns in all cases to prevent unhandled variations of the `'SIGINT' | 'SIGTERM'` union type. While this works because the function lacks a default return, it's brittle and not a compiler-enforced state exhaustiveness check. If a new signal is added and the `switch` is not updated, the compiler flags the missing return instead of pinpointing the unhandled union member via a `never` check.
+
+## Goal
+
+Ensure state handling exhaustiveness is enforced deliberately using a `never` check (e.g., passing the unhandled value to a function expecting `never` or throwing a descriptive error with the unhandled value) rather than relying on TypeScript's default return checking behavior.
+
+## Context
+
+Relying on implicit function return type validation instead of explicit exhaustiveness checking can lead to confusing errors when union types are expanded. Explicitly handling the `default` case and assigning the value to `never` ensures that invalid or missing states are flagged clearly by the compiler directly at the state handling site, making invalid states unrepresentable.
+
+## Evidence
+
+- path: "src/index.ts"
+  loc: "35-42"
+  note: "`signalExitCode` uses a switch statement without a default case asserting the exhaustive check via `never`."
+
+## Change Scope
+
+- `src/index.ts`


### PR DESCRIPTION
This PR emits two high-signal event files from the `typescripter` observer role:

1.  `missing_never_check_typescripter.md`: Flags the `signalExitCode` switch statement for relying on the implicit return type rather than a compiler-enforced `never` check, making the state handling brittle if new signals are added.
2.  `duration_inputs_invalid_state_typescripter.md`: Flags `DurationInputs` for encoding an either/or state (`minutes`, `seconds`) using optional properties, permitting invalid states where both are defined, and `resolveEffectiveSeconds` for handling it via a silent fallback instead of failing explicitly.

---
*PR created automatically by Jules for task [13855958791158511943](https://jules.google.com/task/13855958791158511943) started by @akitorahayashi*