### PR TITLE
test(domain): Add coverage for input validation edge cases

### DIFF
--- a/tests/domain/duration.test.ts
+++ b/tests/domain/duration.test.ts
@@ -33,4 +33,16 @@ describe('resolveEffectiveSeconds', () => {
       "Input 'minutes' must be a non-negative number.",
     )
   })
+
+  it('rejects empty string values for seconds', () => {
+    expect(() => resolveEffectiveSeconds({ seconds: '' })).toThrow(
+      "Input 'seconds' must be a non-negative number.",
+    )
+  })
+
+  it('rejects blank string values for minutes', () => {
+    expect(() => resolveEffectiveSeconds({ minutes: '   ' })).toThrow(
+      "Input 'minutes' must be a non-negative number.",
+    )
+  })
 })

--- a/tests/domain/wait-request.test.ts
+++ b/tests/domain/wait-request.test.ts
@@ -6,15 +6,15 @@ describe('normalizeWaitRequest', () => {
     expect(normalizeWaitRequest({}).enabled).toBe(true)
   })
 
-  it('normalizes false boolean token', () => {
-    expect(normalizeWaitRequest({ enabled: 'false' }).enabled).toBe(false)
-  })
-
-  it('normalizes true boolean tokens', () => {
+  it('normalizes boolean tokens', () => {
     expect(normalizeWaitRequest({ enabled: 'true' }).enabled).toBe(true)
-    expect(normalizeWaitRequest({ enabled: 'yes' }).enabled).toBe(true)
+    expect(normalizeWaitRequest({ enabled: 'YES' }).enabled).toBe(true)
     expect(normalizeWaitRequest({ enabled: 'on' }).enabled).toBe(true)
     expect(normalizeWaitRequest({ enabled: '1' }).enabled).toBe(true)
+    expect(normalizeWaitRequest({ enabled: 'false' }).enabled).toBe(false)
+    expect(normalizeWaitRequest({ enabled: 'no' }).enabled).toBe(false)
+    expect(normalizeWaitRequest({ enabled: 'OFF' }).enabled).toBe(false)
+    expect(normalizeWaitRequest({ enabled: '0' }).enabled).toBe(false)
   })
 
   it('drops empty labels', () => {

--- a/tests/domain/wait-request.test.ts
+++ b/tests/domain/wait-request.test.ts
@@ -10,6 +10,13 @@ describe('normalizeWaitRequest', () => {
     expect(normalizeWaitRequest({ enabled: 'false' }).enabled).toBe(false)
   })
 
+  it('normalizes true boolean tokens', () => {
+    expect(normalizeWaitRequest({ enabled: 'true' }).enabled).toBe(true)
+    expect(normalizeWaitRequest({ enabled: 'yes' }).enabled).toBe(true)
+    expect(normalizeWaitRequest({ enabled: 'on' }).enabled).toBe(true)
+    expect(normalizeWaitRequest({ enabled: '1' }).enabled).toBe(true)
+  })
+
   it('drops empty labels', () => {
     expect(normalizeWaitRequest({ label: '' }).label).toBeUndefined()
   })
@@ -18,5 +25,19 @@ describe('normalizeWaitRequest', () => {
     expect(() => normalizeWaitRequest({ enabled: 'disabled' })).toThrow(
       "Input 'enabled' must be a recognized boolean value.",
     )
+  })
+
+  it('maps seconds to effectiveSeconds', () => {
+    expect(normalizeWaitRequest({ seconds: '15' }).effectiveSeconds).toBe(15)
+  })
+
+  it('maps minutes to effectiveSeconds', () => {
+    expect(normalizeWaitRequest({ minutes: '2' }).effectiveSeconds).toBe(120)
+  })
+
+  it('prioritizes seconds over minutes for effectiveSeconds', () => {
+    expect(
+      normalizeWaitRequest({ seconds: '30', minutes: '5' }).effectiveSeconds,
+    ).toBe(30)
   })
 })


### PR DESCRIPTION
This PR implements the missing test coverage for domain parameter validation and input mapping logic. 
- Covers error paths on empty string values for `minutes` and `seconds`.
- Covers truthy boolean string parsing for `enabled`.
- Verifies property propagation showing how `minutes` and `seconds` map to `effectiveSeconds`.

---
*PR created automatically by Jules for task [11846347999912751958](https://jules.google.com/task/11846347999912751958) started by @akitorahayashi*