### PR TITLE
test: split monolithic action metadata test block

### DIFF
--- a/tests/action/action-metadata.test.ts
+++ b/tests/action/action-metadata.test.ts
@@ -19,14 +19,22 @@ function loadActionFile(path: string): ActionFile {
 }
 
 describe('action metadata contracts', () => {
-  it('declares node24, wait input contract, and wait outputs', () => {
+  it('declares node24 runtime', () => {
     const action = loadActionFile('action.yml')
     expect(action.runs.using).toBe('node24')
     expect(action.runs.main).toBe('dist/index.js')
+  })
+
+  it('declares wait input contract', () => {
+    const action = loadActionFile('action.yml')
     expect(action.inputs.enabled.required).toBe(false)
     expect(action.inputs.minutes.required).toBe(false)
     expect(action.inputs.seconds.required).toBe(false)
     expect(action.inputs.label.required).toBe(false)
+  })
+
+  it('declares wait outputs', () => {
+    const action = loadActionFile('action.yml')
     expect(Object.keys(action.outputs)).toContain('waited')
     expect(Object.keys(action.outputs)).toContain('effective_seconds')
   })

--- a/tests/action/action-metadata.test.ts
+++ b/tests/action/action-metadata.test.ts
@@ -19,14 +19,14 @@ function loadActionFile(path: string): ActionFile {
 }
 
 describe('action metadata contracts', () => {
+  const action = loadActionFile('action.yml')
+
   it('declares node24 runtime', () => {
-    const action = loadActionFile('action.yml')
     expect(action.runs.using).toBe('node24')
     expect(action.runs.main).toBe('dist/index.js')
   })
 
   it('declares wait input contract', () => {
-    const action = loadActionFile('action.yml')
     expect(action.inputs.enabled.required).toBe(false)
     expect(action.inputs.minutes.required).toBe(false)
     expect(action.inputs.seconds.required).toBe(false)
@@ -34,7 +34,6 @@ describe('action metadata contracts', () => {
   })
 
   it('declares wait outputs', () => {
-    const action = loadActionFile('action.yml')
     expect(Object.keys(action.outputs)).toContain('waited')
     expect(Object.keys(action.outputs)).toContain('effective_seconds')
   })


### PR DESCRIPTION
Separated distinct and unrelated assertions regarding the GitHub action metadata into isolated test blocks to ensure unambiguous test failures and precise reporting.

---
*PR created automatically by Jules for task [11120174945699631967](https://jules.google.com/task/11120174945699631967) started by @akitorahayashi*