### PR TITLE
docs: update architecture dependency direction

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,13 +15,17 @@ The runtime boundaries are:
 Runtime dependencies follow this direction:
 
 ```text
-index -> action -> app -> domain
-app -> adapters
-domain -> none
+index -> action, app, adapters
+action -> domain
+app -> domain
 adapters -> node runtime
 ```
 
-`domain` remains pure and does not depend on runtime boundaries.
+The `index.ts` file acts as the root orchestrator. It orchestrates the `action`, `app`, and `adapters` modules.
+
+The `app` module utilizes dependency inversion. It defines an explicit dependency interface instead of importing from `adapters` directly. This protects `app` logic from `adapters`.
+
+The `domain` module remains pure and does not depend on runtime boundaries.
 
 ## Runtime Execution Flow
 


### PR DESCRIPTION
Fixes architectural drift in `docs/architecture.md`.

* Modifies the dependency direction text to accurately reflect the boundaries.
* Explains that `index.ts` acts as the root orchestrator composing the modules.
* Explains that the `app` module utilizes dependency inversion to protect `app` logic from `adapters`.
* Removes incorrect statements about `action -> app` and `app -> adapters` dependency direction.
* Avoids using bold markdown formatting, adhering to constraints.

---
*PR created automatically by Jules for task [12741735071719815886](https://jules.google.com/task/12741735071719815886) started by @akitorahayashi*