### PR TITLE
refactor(signal): enforce explicit exhaustiveness checking

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,10 @@ export function signalExitCode(signal: 'SIGINT' | 'SIGTERM'): number {
       return 130
     case 'SIGTERM':
       return 143
+    default: {
+      const _exhaustiveCheck: never = signal
+      return _exhaustiveCheck
+    }
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,7 @@ export function signalExitCode(signal: 'SIGINT' | 'SIGTERM'): number {
       return 143
     default: {
       const _exhaustiveCheck: never = signal
-      return _exhaustiveCheck
+      throw new Error(`Unexpected signal: ${_exhaustiveCheck}`)
     }
   }
 }


### PR DESCRIPTION
Refactor the `signalExitCode` function to explicitly check for state handling exhaustiveness using a `never` assignment in a `default` case.

This ensures that any future expansion of the signal union type will result in a compile-time failure pinpointing the exact unhandled member, rather than relying on implicit function return type validation which can lead to confusing errors.

---
*PR created automatically by Jules for task [17762600436324086692](https://jules.google.com/task/17762600436324086692) started by @akitorahayashi*