### PR TITLE
refactor: standardize wait taxonomy across domain and adapters

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -25751,16 +25751,16 @@ function readOptionalInput(name) {
 
 /***/ }),
 
-/***/ 832:
+/***/ 8050:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.WaitCancelledError = void 0;
-exports.cancellationAwareDelay = cancellationAwareDelay;
+exports.cancellationAwareWait = cancellationAwareWait;
 /**
- * Provides the technical delay mechanism to fulfill the domain's wait request.
+ * Provides the technical wait mechanism to fulfill the domain's wait request.
  */
 class WaitCancelledError extends Error {
     signal;
@@ -25772,8 +25772,8 @@ class WaitCancelledError extends Error {
 }
 exports.WaitCancelledError = WaitCancelledError;
 const MILLISECONDS_PER_SECOND = 1000;
-const SECONDS_PER_DELAY_CHUNK = 60;
-async function cancellationAwareDelay(seconds) {
+const SECONDS_PER_WAIT_CHUNK = 60;
+async function cancellationAwareWait(seconds) {
     if (seconds <= 0) {
         return;
     }
@@ -25819,7 +25819,7 @@ async function cancellationAwareDelay(seconds) {
                 resolve();
                 return;
             }
-            const chunkSeconds = Math.min(remainingSeconds, SECONDS_PER_DELAY_CHUNK);
+            const chunkSeconds = Math.min(remainingSeconds, SECONDS_PER_WAIT_CHUNK);
             remainingSeconds -= chunkSeconds;
             try {
                 timeout = setTimeout(scheduleNextChunk, chunkSeconds * MILLISECONDS_PER_SECOND);
@@ -25853,7 +25853,7 @@ async function executeWait(request, dependencies) {
         return { waited: false, effectiveSeconds: request.effectiveSeconds };
     }
     dependencies.log(`Starting wait for ${request.effectiveSeconds} second(s).${labelSegment}`);
-    await dependencies.delay(request.effectiveSeconds);
+    await dependencies.wait(request.effectiveSeconds);
     dependencies.log(`Wait completed after ${request.effectiveSeconds} second(s).${labelSegment}`);
     return { waited: true, effectiveSeconds: request.effectiveSeconds };
 }
@@ -25982,19 +25982,19 @@ exports.signalExitCode = signalExitCode;
 const core = __importStar(__nccwpck_require__(7484));
 const emit_outputs_1 = __nccwpck_require__(8340);
 const read_inputs_1 = __nccwpck_require__(2316);
-const cancellation_aware_delay_1 = __nccwpck_require__(832);
+const cancellation_aware_wait_1 = __nccwpck_require__(8050);
 const execute_wait_1 = __nccwpck_require__(9811);
 async function run() {
     const request = (0, read_inputs_1.readInputs)();
     const result = await (0, execute_wait_1.executeWait)(request, {
-        delay: cancellation_aware_delay_1.cancellationAwareDelay,
+        wait: cancellation_aware_wait_1.cancellationAwareWait,
         log: core.info,
     });
     (0, emit_outputs_1.emitOutputs)(result);
     core.debug('Wait action completed.');
 }
 function handleError(error) {
-    if (error instanceof cancellation_aware_delay_1.WaitCancelledError) {
+    if (error instanceof cancellation_aware_wait_1.WaitCancelledError) {
         core.notice(error.message);
         process.exitCode = signalExitCode(error.signal);
         return;

--- a/src/adapters/cancellation-aware-wait.ts
+++ b/src/adapters/cancellation-aware-wait.ts
@@ -1,5 +1,5 @@
 /**
- * Provides the technical delay mechanism to fulfill the domain's wait request.
+ * Provides the technical wait mechanism to fulfill the domain's wait request.
  */
 export class WaitCancelledError extends Error {
   public readonly signal: 'SIGINT' | 'SIGTERM'
@@ -12,9 +12,9 @@ export class WaitCancelledError extends Error {
 }
 
 const MILLISECONDS_PER_SECOND = 1000
-const SECONDS_PER_DELAY_CHUNK = 60
+const SECONDS_PER_WAIT_CHUNK = 60
 
-export async function cancellationAwareDelay(seconds: number): Promise<void> {
+export async function cancellationAwareWait(seconds: number): Promise<void> {
   if (seconds <= 0) {
     return
   }
@@ -70,7 +70,7 @@ export async function cancellationAwareDelay(seconds: number): Promise<void> {
         return
       }
 
-      const chunkSeconds = Math.min(remainingSeconds, SECONDS_PER_DELAY_CHUNK)
+      const chunkSeconds = Math.min(remainingSeconds, SECONDS_PER_WAIT_CHUNK)
       remainingSeconds -= chunkSeconds
       try {
         timeout = setTimeout(

--- a/src/app/execute-wait/execute-wait-dependencies.ts
+++ b/src/app/execute-wait/execute-wait-dependencies.ts
@@ -1,4 +1,4 @@
 export interface ExecuteWaitDependencies {
-  delay: (seconds: number) => Promise<void>
+  wait: (seconds: number) => Promise<void>
   log: (message: string) => void
 }

--- a/src/app/execute-wait/index.ts
+++ b/src/app/execute-wait/index.ts
@@ -25,7 +25,7 @@ export async function executeWait(
   dependencies.log(
     `Starting wait for ${request.effectiveSeconds} second(s).${labelSegment}`,
   )
-  await dependencies.delay(request.effectiveSeconds)
+  await dependencies.wait(request.effectiveSeconds)
   dependencies.log(
     `Wait completed after ${request.effectiveSeconds} second(s).${labelSegment}`,
   )

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,14 +3,14 @@ import { emitOutputs } from './action/emit-outputs'
 import { readInputs } from './action/read-inputs'
 import {
   WaitCancelledError,
-  cancellationAwareDelay,
-} from './adapters/cancellation-aware-delay'
+  cancellationAwareWait,
+} from './adapters/cancellation-aware-wait'
 import { executeWait } from './app/execute-wait'
 
 export async function run(): Promise<void> {
   const request = readInputs()
   const result = await executeWait(request, {
-    delay: cancellationAwareDelay,
+    wait: cancellationAwareWait,
     log: core.info,
   })
 

--- a/tests/adapters/cancellation-aware-wait.test.ts
+++ b/tests/adapters/cancellation-aware-wait.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   WaitCancelledError,
-  cancellationAwareDelay,
-} from '../../src/adapters/cancellation-aware-delay'
+  cancellationAwareWait,
+} from '../../src/adapters/cancellation-aware-wait'
 
 function captureSignalHandlers(): {
   handlers: Map<NodeJS.Signals, () => void>
@@ -43,7 +43,7 @@ function captureSignalHandlers(): {
   }
 }
 
-describe('cancellationAwareDelay', () => {
+describe('cancellationAwareWait', () => {
   afterEach(() => {
     vi.useRealTimers()
   })
@@ -52,14 +52,14 @@ describe('cancellationAwareDelay', () => {
     { duration: 0, description: 'is 0' },
     { duration: -5, description: 'is negative' },
   ])('resolves immediately if duration $description', async ({ duration }) => {
-    const waitPromise = cancellationAwareDelay(duration)
+    const waitPromise = cancellationAwareWait(duration)
     await expect(waitPromise).resolves.toBeUndefined()
   })
 
   it('resolves after the requested duration', async () => {
     vi.useFakeTimers()
 
-    const waitPromise = cancellationAwareDelay(2)
+    const waitPromise = cancellationAwareWait(2)
     await vi.advanceTimersByTimeAsync(2000)
 
     await expect(waitPromise).resolves.toBeUndefined()
@@ -70,7 +70,7 @@ describe('cancellationAwareDelay', () => {
     const { handlers, restore } = captureSignalHandlers()
 
     try {
-      const waitPromise = cancellationAwareDelay(60)
+      const waitPromise = cancellationAwareWait(60)
       const handler = handlers.get('SIGINT')
 
       expect(handler).toBeTypeOf('function')
@@ -88,7 +88,7 @@ describe('cancellationAwareDelay', () => {
     const { handlers, restore } = captureSignalHandlers()
 
     try {
-      const waitPromise = cancellationAwareDelay(60)
+      const waitPromise = cancellationAwareWait(60)
       const handler = handlers.get('SIGTERM')
 
       expect(handler).toBeTypeOf('function')
@@ -101,10 +101,10 @@ describe('cancellationAwareDelay', () => {
     }
   })
 
-  it('resolves correctly for chunked delays longer than 60 seconds', async () => {
+  it('resolves correctly for chunked waits longer than 60 seconds', async () => {
     vi.useFakeTimers()
 
-    const waitPromise = cancellationAwareDelay(150) // 60s + 60s + 30s
+    const waitPromise = cancellationAwareWait(150) // 60s + 60s + 30s
     await vi.advanceTimersByTimeAsync(60_000)
     await vi.advanceTimersByTimeAsync(60_000)
     await vi.advanceTimersByTimeAsync(30_000)
@@ -112,12 +112,12 @@ describe('cancellationAwareDelay', () => {
     await expect(waitPromise).resolves.toBeUndefined()
   })
 
-  it('cancels properly during a subsequent chunk of a long delay', async () => {
+  it('cancels properly during a subsequent chunk of a long wait', async () => {
     vi.useFakeTimers()
     const { handlers, restore } = captureSignalHandlers()
 
     try {
-      const waitPromise = cancellationAwareDelay(150)
+      const waitPromise = cancellationAwareWait(150)
       await vi.advanceTimersByTimeAsync(60_000)
 
       const handler = handlers.get('SIGINT')
@@ -140,7 +140,7 @@ describe('cancellationAwareDelay', () => {
     })
 
     try {
-      const waitPromise = cancellationAwareDelay(2)
+      const waitPromise = cancellationAwareWait(2)
       await expect(waitPromise).rejects.toThrow(
         'Failed to install cancellation handlers.',
       )
@@ -165,7 +165,7 @@ describe('cancellationAwareDelay', () => {
       })
 
     try {
-      const waitPromise = cancellationAwareDelay(2)
+      const waitPromise = cancellationAwareWait(2)
       await expect(waitPromise).rejects.toThrow('Failed to start wait timer.')
 
       try {
@@ -183,7 +183,7 @@ describe('cancellationAwareDelay', () => {
     const { handlers, restore } = captureSignalHandlers()
 
     try {
-      const waitPromise = cancellationAwareDelay(60)
+      const waitPromise = cancellationAwareWait(60)
       const handler = handlers.get('SIGINT')
 
       expect(handler).toBeTypeOf('function')
@@ -210,7 +210,7 @@ describe('cancellationAwareDelay', () => {
     }) as typeof setTimeout)
 
     try {
-      const waitPromise = cancellationAwareDelay(150)
+      const waitPromise = cancellationAwareWait(150)
 
       const handler = handlers.get('SIGINT')
       expect(handler).toBeTypeOf('function')

--- a/tests/app/execute-wait.test.ts
+++ b/tests/app/execute-wait.test.ts
@@ -3,7 +3,7 @@ import { executeWait } from '../../src/app/execute-wait'
 
 describe('executeWait', () => {
   it('skips when enabled is false', async () => {
-    const delay = vi.fn<(seconds: number) => Promise<void>>()
+    const wait = vi.fn<(seconds: number) => Promise<void>>()
     const log = vi.fn<(message: string) => void>()
 
     const result = await executeWait(
@@ -12,18 +12,18 @@ describe('executeWait', () => {
         effectiveSeconds: 20,
         label: undefined,
       },
-      { delay, log },
+      { wait, log },
     )
 
     expect(result).toEqual({ waited: false, effectiveSeconds: 20 })
-    expect(delay).not.toHaveBeenCalled()
+    expect(wait).not.toHaveBeenCalled()
     expect(log).toHaveBeenCalledWith(
       'Skipping wait because enabled=false. effective_seconds=20.',
     )
   })
 
   it('skips when effective duration is zero', async () => {
-    const delay = vi.fn<(seconds: number) => Promise<void>>()
+    const wait = vi.fn<(seconds: number) => Promise<void>>()
     const log = vi.fn<(message: string) => void>()
 
     const result = await executeWait(
@@ -32,20 +32,18 @@ describe('executeWait', () => {
         effectiveSeconds: 0,
         label: 'build',
       },
-      { delay, log },
+      { wait, log },
     )
 
     expect(result).toEqual({ waited: false, effectiveSeconds: 0 })
-    expect(delay).not.toHaveBeenCalled()
+    expect(wait).not.toHaveBeenCalled()
     expect(log).toHaveBeenCalledWith(
       'Skipping wait because effective_seconds=0. label=build',
     )
   })
 
   it('waits when enabled and duration is positive', async () => {
-    const delay = vi
-      .fn<(seconds: number) => Promise<void>>()
-      .mockResolvedValue()
+    const wait = vi.fn<(seconds: number) => Promise<void>>().mockResolvedValue()
     const log = vi.fn<(message: string) => void>()
 
     const result = await executeWait(
@@ -54,11 +52,11 @@ describe('executeWait', () => {
         effectiveSeconds: 12,
         label: 'deploy',
       },
-      { delay, log },
+      { wait, log },
     )
 
     expect(result).toEqual({ waited: true, effectiveSeconds: 12 })
-    expect(delay).toHaveBeenCalledWith(12)
+    expect(wait).toHaveBeenCalledWith(12)
     expect(log).toHaveBeenCalledWith(
       'Starting wait for 12 second(s). label=deploy',
     )
@@ -67,8 +65,8 @@ describe('executeWait', () => {
     )
   })
 
-  it('propagates delay failures', async () => {
-    const delay = vi
+  it('propagates wait failures', async () => {
+    const wait = vi
       .fn<(seconds: number) => Promise<void>>()
       .mockRejectedValue(new Error('cancelled'))
 
@@ -79,7 +77,7 @@ describe('executeWait', () => {
           effectiveSeconds: 15,
           label: undefined,
         },
-        { delay, log: vi.fn() },
+        { wait, log: vi.fn() },
       ),
     ).rejects.toThrow('cancelled')
   })

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import * as core from '@actions/core'
 import { run, handleError, signalExitCode } from '../src/index'
-import { WaitCancelledError } from '../src/adapters/cancellation-aware-delay'
+import { WaitCancelledError } from '../src/adapters/cancellation-aware-wait'
 import * as readInputsModule from '../src/action/read-inputs'
 import * as executeWaitModule from '../src/app/execute-wait'
 import * as emitOutputsModule from '../src/action/emit-outputs'
@@ -12,14 +12,14 @@ vi.mock('@actions/core')
 vi.mock('../src/action/read-inputs')
 vi.mock('../src/app/execute-wait')
 vi.mock('../src/action/emit-outputs')
-vi.mock('../src/adapters/cancellation-aware-delay', async (importOriginal) => {
+vi.mock('../src/adapters/cancellation-aware-wait', async (importOriginal) => {
   const actual =
     await importOriginal<
-      typeof import('../src/adapters/cancellation-aware-delay')
+      typeof import('../src/adapters/cancellation-aware-wait')
     >()
   return {
     ...actual,
-    cancellationAwareDelay: vi.fn(),
+    cancellationAwareWait: vi.fn(),
   }
 })
 
@@ -48,7 +48,7 @@ describe('index bootstrap', () => {
       expect(executeWaitModule.executeWait).toHaveBeenCalledWith(
         mockRequest,
         expect.objectContaining({
-          delay: expect.any(Function),
+          wait: expect.any(Function),
           log: core.info,
         }),
       )


### PR DESCRIPTION
Standardizes terms across the domain, boundaries, and documentation to use the canonical term `wait` uniformly for pausing execution, eliminating the near-synonym `delay`.

---
*PR created automatically by Jules for task [9797295730229996304](https://jules.google.com/task/9797295730229996304) started by @akitorahayashi*