### PR TITLE
refactor: explicit validation using result pattern

### DIFF
--- a/src/action/read-inputs.ts
+++ b/src/action/read-inputs.ts
@@ -1,11 +1,15 @@
 import * as core from '@actions/core'
 import { createWaitRequest, type WaitRequest } from '../domain/wait-request'
 import type { DurationInput } from '../domain/duration'
-import { type Result, err } from '../domain/result'
+import { type Result, ok, err } from '../domain/result'
 
 export function readInputs(): Result<WaitRequest, Error> {
   const enabledInput = readOptionalInput('enabled')
-  const enabled = parseBooleanInput(enabledInput, true, 'enabled')
+  const enabledResult = parseBooleanInput(enabledInput, true, 'enabled')
+  if (!enabledResult.ok) {
+    return enabledResult
+  }
+  const enabled = enabledResult.value
 
   const minutesInput = readOptionalInput('minutes')
   const secondsInput = readOptionalInput('seconds')
@@ -47,19 +51,19 @@ function parseBooleanInput(
   value: string | undefined,
   defaultValue: boolean,
   name: string,
-): boolean {
+): Result<boolean, Error> {
   if (value === undefined) {
-    return defaultValue
+    return ok(defaultValue)
   }
 
   const normalizedValue = value.toLowerCase()
   if (['1', 'true', 'yes', 'on'].includes(normalizedValue)) {
-    return true
+    return ok(true)
   }
 
   if (['0', 'false', 'no', 'off'].includes(normalizedValue)) {
-    return false
+    return ok(false)
   }
 
-  throw new Error(`Input '${name}' must be a recognized boolean value.`)
+  return err(new Error(`Input '${name}' must be a recognized boolean value.`))
 }

--- a/src/action/read-inputs.ts
+++ b/src/action/read-inputs.ts
@@ -1,17 +1,65 @@
 import * as core from '@actions/core'
-import { normalizeWaitRequest, type WaitRequest } from '../domain/wait-request'
+import { createWaitRequest, type WaitRequest } from '../domain/wait-request'
+import type { DurationInput } from '../domain/duration'
+import { type Result, err } from '../domain/result'
 
-export function readInputs(): WaitRequest {
-  return normalizeWaitRequest({
-    enabled: readOptionalInput('enabled'),
-    minutes: readOptionalInput('minutes'),
-    seconds: readOptionalInput('seconds'),
-    label: readOptionalInput('label'),
-  })
+export function readInputs(): Result<WaitRequest, Error> {
+  const enabledInput = readOptionalInput('enabled')
+  const enabled = parseBooleanInput(enabledInput, true, 'enabled')
+
+  const minutesInput = readOptionalInput('minutes')
+  const secondsInput = readOptionalInput('seconds')
+
+  if (minutesInput !== undefined && secondsInput !== undefined) {
+    return err(
+      new Error(
+        "Inputs 'minutes' and 'seconds' are mutually exclusive. Please provide only one.",
+      ),
+    )
+  }
+
+  let duration: DurationInput = {}
+
+  if (minutesInput !== undefined) {
+    const parsedMinutes = Number(minutesInput)
+    if (Number.isNaN(parsedMinutes)) {
+      return err(new Error("Input 'minutes' must be a non-negative number."))
+    }
+    duration = { minutes: parsedMinutes }
+  } else if (secondsInput !== undefined) {
+    const parsedSeconds = Number(secondsInput)
+    if (Number.isNaN(parsedSeconds)) {
+      return err(new Error("Input 'seconds' must be a non-negative number."))
+    }
+    duration = { seconds: parsedSeconds }
+  }
+
+  return createWaitRequest(enabled, duration, readOptionalInput('label'))
 }
 
 function readOptionalInput(name: string): string | undefined {
   const value = core.getInput(name)
   const normalized = value.trim()
   return normalized.length === 0 ? undefined : normalized
+}
+
+function parseBooleanInput(
+  value: string | undefined,
+  defaultValue: boolean,
+  name: string,
+): boolean {
+  if (value === undefined) {
+    return defaultValue
+  }
+
+  const normalizedValue = value.toLowerCase()
+  if (['1', 'true', 'yes', 'on'].includes(normalizedValue)) {
+    return true
+  }
+
+  if (['0', 'false', 'no', 'off'].includes(normalizedValue)) {
+    return false
+  }
+
+  throw new Error(`Input '${name}' must be a recognized boolean value.`)
 }

--- a/src/domain/duration.ts
+++ b/src/domain/duration.ts
@@ -1,41 +1,39 @@
-export interface DurationInputs {
-  minutes?: string
-  seconds?: string
-}
+import { type Result, ok, err } from './result'
+
+export type DurationInput =
+  | { minutes: number }
+  | { seconds: number }
+  | Record<string, never>
 
 const SECONDS_PER_MINUTE = 60
 
-export function resolveEffectiveSeconds(inputs: DurationInputs): number {
-  if (inputs.seconds !== undefined) {
-    return normalizeToIntegerSeconds(
-      parseNonNegativeNumber('seconds', inputs.seconds),
-    )
+export function resolveEffectiveSeconds(
+  input: DurationInput,
+): Result<number, Error> {
+  if ('seconds' in input) {
+    return parseNonNegativeNumber('seconds', input.seconds).ok
+      ? ok(normalizeToIntegerSeconds(input.seconds))
+      : err(new Error("Input 'seconds' must be a non-negative number."))
   }
 
-  if (inputs.minutes !== undefined) {
-    return normalizeToIntegerSeconds(
-      parseNonNegativeNumber('minutes', inputs.minutes) * SECONDS_PER_MINUTE,
-    )
+  if ('minutes' in input) {
+    return parseNonNegativeNumber('minutes', input.minutes).ok
+      ? ok(normalizeToIntegerSeconds(input.minutes * SECONDS_PER_MINUTE))
+      : err(new Error("Input 'minutes' must be a non-negative number."))
   }
 
-  return 0
+  return ok(0)
 }
 
 function parseNonNegativeNumber(
   name: 'minutes' | 'seconds',
-  value: string,
-): number {
-  const normalized = value.trim()
-  if (normalized.length === 0) {
-    throw new Error(`Input '${name}' must be a non-negative number.`)
-  }
-
-  const parsed = Number(normalized)
+  parsed: number,
+): Result<number, Error> {
   if (!Number.isFinite(parsed) || parsed < 0) {
-    throw new Error(`Input '${name}' must be a non-negative number.`)
+    return err(new Error(`Input '${name}' must be a non-negative number.`))
   }
 
-  return parsed
+  return ok(parsed)
 }
 
 function normalizeToIntegerSeconds(value: number): number {

--- a/src/domain/duration.ts
+++ b/src/domain/duration.ts
@@ -11,15 +11,17 @@ export function resolveEffectiveSeconds(
   input: DurationInput,
 ): Result<number, Error> {
   if ('seconds' in input) {
-    return parseNonNegativeNumber('seconds', input.seconds).ok
-      ? ok(normalizeToIntegerSeconds(input.seconds))
-      : err(new Error("Input 'seconds' must be a non-negative number."))
+    const secondsResult = parseNonNegativeNumber('seconds', input.seconds)
+    return secondsResult.ok
+      ? ok(normalizeToIntegerSeconds(secondsResult.value))
+      : secondsResult
   }
 
   if ('minutes' in input) {
-    return parseNonNegativeNumber('minutes', input.minutes).ok
-      ? ok(normalizeToIntegerSeconds(input.minutes * SECONDS_PER_MINUTE))
-      : err(new Error("Input 'minutes' must be a non-negative number."))
+    const minutesResult = parseNonNegativeNumber('minutes', input.minutes)
+    return minutesResult.ok
+      ? ok(normalizeToIntegerSeconds(minutesResult.value * SECONDS_PER_MINUTE))
+      : minutesResult
   }
 
   return ok(0)

--- a/src/domain/result.ts
+++ b/src/domain/result.ts
@@ -1,0 +1,21 @@
+export type Result<T, E> = { ok: true; value: T } | { ok: false; error: E }
+
+export function ok<T, E>(value: T): Result<T, E> {
+  return { ok: true, value }
+}
+
+export function err<T, E>(error: E): Result<T, E> {
+  return { ok: false, error }
+}
+
+export function isOk<T, E>(
+  result: Result<T, E>,
+): result is { ok: true; value: T } {
+  return result.ok === true
+}
+
+export function isErr<T, E>(
+  result: Result<T, E>,
+): result is { ok: false; error: E } {
+  return result.ok === false
+}

--- a/src/domain/wait-request.ts
+++ b/src/domain/wait-request.ts
@@ -1,4 +1,5 @@
-import { resolveEffectiveSeconds } from './duration'
+import { resolveEffectiveSeconds, type DurationInput } from './duration'
+import { type Result, ok, err } from './result'
 
 export interface WaitRequest {
   enabled: boolean
@@ -6,43 +7,22 @@ export interface WaitRequest {
   label?: string
 }
 
-export interface RawWaitInputs {
-  enabled?: string
-  minutes?: string
-  seconds?: string
-  label?: string
-}
+export function createWaitRequest(
+  enabled: boolean,
+  duration: DurationInput,
+  label?: string,
+): Result<WaitRequest, Error> {
+  const effectiveSecondsResult = resolveEffectiveSeconds(duration)
 
-export function normalizeWaitRequest(raw: RawWaitInputs): WaitRequest {
-  return {
-    enabled: parseBooleanInput(raw.enabled, true, 'enabled'),
-    effectiveSeconds: resolveEffectiveSeconds({
-      minutes: raw.minutes,
-      seconds: raw.seconds,
-    }),
-    label: normalizeLabel(raw.label),
-  }
-}
-
-function parseBooleanInput(
-  value: string | undefined,
-  defaultValue: boolean,
-  name: string,
-): boolean {
-  if (value === undefined) {
-    return defaultValue
+  if (!effectiveSecondsResult.ok) {
+    return err(effectiveSecondsResult.error)
   }
 
-  const normalizedValue = value.toLowerCase()
-  if (['1', 'true', 'yes', 'on'].includes(normalizedValue)) {
-    return true
-  }
-
-  if (['0', 'false', 'no', 'off'].includes(normalizedValue)) {
-    return false
-  }
-
-  throw new Error(`Input '${name}' must be a recognized boolean value.`)
+  return ok({
+    enabled,
+    effectiveSeconds: effectiveSecondsResult.value,
+    label: normalizeLabel(label),
+  })
 }
 
 function normalizeLabel(value: string | undefined): string | undefined {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,8 +8,14 @@ import {
 import { executeWait } from './app/execute-wait'
 
 export async function run(): Promise<void> {
-  const request = readInputs()
-  const result = await executeWait(request, {
+  const requestResult = readInputs()
+
+  if (!requestResult.ok) {
+    core.setFailed(requestResult.error.message)
+    return
+  }
+
+  const result = await executeWait(requestResult.value, {
     delay: cancellationAwareDelay,
     log: core.info,
   })

--- a/tests/action/read-inputs.test.ts
+++ b/tests/action/read-inputs.test.ts
@@ -87,9 +87,14 @@ describe('readInputs', () => {
       return ''
     })
 
-    expect(() => readInputs()).toThrow(
-      "Input 'enabled' must be a recognized boolean value.",
-    )
+    const result = readInputs()
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error.message).toBe(
+        "Input 'enabled' must be a recognized boolean value.",
+      )
+    }
   })
 
   it('fails when parsing non-numeric duration string', () => {

--- a/tests/action/read-inputs.test.ts
+++ b/tests/action/read-inputs.test.ts
@@ -1,18 +1,19 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import * as core from '@actions/core'
 import { readInputs } from '../../src/action/read-inputs'
-import { normalizeWaitRequest } from '../../src/domain/wait-request'
+import { createWaitRequest } from '../../src/domain/wait-request'
+import { ok } from '../../src/domain/result'
 
 vi.mock('@actions/core', () => ({
   getInput: vi.fn(),
 }))
 
 vi.mock('../../src/domain/wait-request', () => ({
-  normalizeWaitRequest: vi.fn(),
+  createWaitRequest: vi.fn(),
 }))
 
 const mockedGetInput = vi.mocked(core.getInput)
-const mockedNormalizeWaitRequest = vi.mocked(normalizeWaitRequest)
+const mockedCreateWaitRequest = vi.mocked(createWaitRequest)
 
 describe('readInputs', () => {
   afterEach(() => {
@@ -20,12 +21,14 @@ describe('readInputs', () => {
   })
 
   it('reads and trims inputs before passing them to the domain layer', () => {
+    mockedCreateWaitRequest.mockReturnValue(
+      ok({ enabled: false, effectiveSeconds: 10, label: 'my label' }),
+    )
+
     mockedGetInput.mockImplementation((name: string) => {
       switch (name) {
         case 'enabled':
           return '  false  '
-        case 'minutes':
-          return '  2  '
         case 'seconds':
           return '  10  '
         case 'label':
@@ -37,24 +40,71 @@ describe('readInputs', () => {
 
     readInputs()
 
-    expect(mockedNormalizeWaitRequest).toHaveBeenCalledWith({
-      enabled: 'false',
-      minutes: '2',
-      seconds: '10',
-      label: 'my label',
-    })
+    expect(mockedCreateWaitRequest).toHaveBeenCalledWith(
+      false,
+      { seconds: 10 },
+      'my label',
+    )
   })
 
   it('treats empty or whitespace-only inputs as absent', () => {
+    mockedCreateWaitRequest.mockReturnValue(
+      ok({ enabled: true, effectiveSeconds: 0 }),
+    )
+
     mockedGetInput.mockReturnValue('   ')
 
     readInputs()
 
-    expect(mockedNormalizeWaitRequest).toHaveBeenCalledWith({
-      enabled: undefined,
-      minutes: undefined,
-      seconds: undefined,
-      label: undefined,
+    expect(mockedCreateWaitRequest).toHaveBeenCalledWith(true, {}, undefined)
+  })
+
+  it('returns explicit error when mutually exclusive inputs are provided', () => {
+    mockedGetInput.mockImplementation((name: string) => {
+      switch (name) {
+        case 'minutes':
+          return '2'
+        case 'seconds':
+          return '10'
+        default:
+          return ''
+      }
     })
+
+    const result = readInputs()
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error.message).toBe(
+        "Inputs 'minutes' and 'seconds' are mutually exclusive. Please provide only one.",
+      )
+    }
+  })
+
+  it('fails for unknown boolean token', () => {
+    mockedGetInput.mockImplementation((name: string) => {
+      if (name === 'enabled') return 'disabled'
+      return ''
+    })
+
+    expect(() => readInputs()).toThrow(
+      "Input 'enabled' must be a recognized boolean value.",
+    )
+  })
+
+  it('fails when parsing non-numeric duration string', () => {
+    mockedGetInput.mockImplementation((name: string) => {
+      if (name === 'minutes') return 'abc'
+      return ''
+    })
+
+    const result = readInputs()
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error.message).toBe(
+        "Input 'minutes' must be a non-negative number.",
+      )
+    }
   })
 })

--- a/tests/domain/duration.test.ts
+++ b/tests/domain/duration.test.ts
@@ -43,16 +43,4 @@ describe('resolveEffectiveSeconds', () => {
       value: 1,
     })
   })
-
-  it('rejects empty string values for seconds', () => {
-    expect(() => resolveEffectiveSeconds({ seconds: '' })).toThrow(
-      "Input 'seconds' must be a non-negative number.",
-    )
-  })
-
-  it('rejects blank string values for minutes', () => {
-    expect(() => resolveEffectiveSeconds({ minutes: '   ' })).toThrow(
-      "Input 'minutes' must be a non-negative number.",
-    )
-  })
 })

--- a/tests/domain/duration.test.ts
+++ b/tests/domain/duration.test.ts
@@ -3,34 +3,44 @@ import { resolveEffectiveSeconds } from '../../src/domain/duration'
 
 describe('resolveEffectiveSeconds', () => {
   it('returns zero when no duration inputs are provided', () => {
-    expect(resolveEffectiveSeconds({})).toBe(0)
+    expect(resolveEffectiveSeconds({})).toEqual({ ok: true, value: 0 })
   })
 
   it('uses seconds when provided', () => {
-    expect(resolveEffectiveSeconds({ seconds: '9', minutes: '5' })).toBe(9)
+    expect(resolveEffectiveSeconds({ seconds: 9 })).toEqual({
+      ok: true,
+      value: 9,
+    })
   })
 
   it('converts minutes to seconds when seconds is absent', () => {
-    expect(resolveEffectiveSeconds({ minutes: '3' })).toBe(180)
+    expect(resolveEffectiveSeconds({ minutes: 3 })).toEqual({
+      ok: true,
+      value: 180,
+    })
   })
 
   it('rejects negative values', () => {
-    expect(() => resolveEffectiveSeconds({ seconds: '-1' })).toThrow(
-      "Input 'seconds' must be a non-negative number.",
-    )
+    const result = resolveEffectiveSeconds({ seconds: -1 })
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error.message).toBe(
+        "Input 'seconds' must be a non-negative number.",
+      )
+    }
   })
 
   it('accepts decimal seconds and truncates', () => {
-    expect(resolveEffectiveSeconds({ seconds: '30.9' })).toBe(30)
+    expect(resolveEffectiveSeconds({ seconds: 30.9 })).toEqual({
+      ok: true,
+      value: 30,
+    })
   })
 
   it('accepts decimal minutes and truncates after conversion', () => {
-    expect(resolveEffectiveSeconds({ minutes: '0.02' })).toBe(1)
-  })
-
-  it('rejects non-numeric values', () => {
-    expect(() => resolveEffectiveSeconds({ minutes: 'abc' })).toThrow(
-      "Input 'minutes' must be a non-negative number.",
-    )
+    expect(resolveEffectiveSeconds({ minutes: 0.02 })).toEqual({
+      ok: true,
+      value: 1,
+    })
   })
 })

--- a/tests/domain/wait-request.test.ts
+++ b/tests/domain/wait-request.test.ts
@@ -1,20 +1,18 @@
 import { describe, expect, it } from 'vitest'
 import { createWaitRequest } from '../../src/domain/wait-request'
 
-describe('normalizeWaitRequest', () => {
-  it('defaults enabled to true', () => {
-    expect(normalizeWaitRequest({}).enabled).toBe(true)
-  })
+describe('createWaitRequest', () => {
+  it('builds a wait request with the provided enabled value', () => {
+    const result = createWaitRequest(false, {})
 
-  it('normalizes boolean tokens', () => {
-    expect(normalizeWaitRequest({ enabled: 'true' }).enabled).toBe(true)
-    expect(normalizeWaitRequest({ enabled: 'YES' }).enabled).toBe(true)
-    expect(normalizeWaitRequest({ enabled: 'on' }).enabled).toBe(true)
-    expect(normalizeWaitRequest({ enabled: '1' }).enabled).toBe(true)
-    expect(normalizeWaitRequest({ enabled: 'false' }).enabled).toBe(false)
-    expect(normalizeWaitRequest({ enabled: 'no' }).enabled).toBe(false)
-    expect(normalizeWaitRequest({ enabled: 'OFF' }).enabled).toBe(false)
-    expect(normalizeWaitRequest({ enabled: '0' }).enabled).toBe(false)
+    expect(result).toEqual({
+      ok: true,
+      value: {
+        enabled: false,
+        effectiveSeconds: 0,
+        label: undefined,
+      },
+    })
   })
 
   it('drops empty labels', () => {
@@ -36,16 +34,28 @@ describe('normalizeWaitRequest', () => {
   })
 
   it('maps seconds to effectiveSeconds', () => {
-    expect(normalizeWaitRequest({ seconds: '15' }).effectiveSeconds).toBe(15)
+    const result = createWaitRequest(true, { seconds: 15 })
+
+    expect(result).toEqual({
+      ok: true,
+      value: {
+        enabled: true,
+        effectiveSeconds: 15,
+        label: undefined,
+      },
+    })
   })
 
   it('maps minutes to effectiveSeconds', () => {
-    expect(normalizeWaitRequest({ minutes: '2' }).effectiveSeconds).toBe(120)
-  })
+    const result = createWaitRequest(true, { minutes: 2 })
 
-  it('prioritizes seconds over minutes for effectiveSeconds', () => {
-    expect(
-      normalizeWaitRequest({ seconds: '30', minutes: '5' }).effectiveSeconds,
-    ).toBe(30)
+    expect(result).toEqual({
+      ok: true,
+      value: {
+        enabled: true,
+        effectiveSeconds: 120,
+        label: undefined,
+      },
+    })
   })
 })

--- a/tests/domain/wait-request.test.ts
+++ b/tests/domain/wait-request.test.ts
@@ -1,22 +1,34 @@
 import { describe, expect, it } from 'vitest'
-import { normalizeWaitRequest } from '../../src/domain/wait-request'
+import { createWaitRequest } from '../../src/domain/wait-request'
 
-describe('normalizeWaitRequest', () => {
-  it('defaults enabled to true', () => {
-    expect(normalizeWaitRequest({}).enabled).toBe(true)
-  })
-
-  it('normalizes false boolean token', () => {
-    expect(normalizeWaitRequest({ enabled: 'false' }).enabled).toBe(false)
+describe('createWaitRequest', () => {
+  it('maps valid inputs into wait request', () => {
+    const result = createWaitRequest(true, { seconds: 10 }, 'my label')
+    expect(result).toEqual({
+      ok: true,
+      value: {
+        enabled: true,
+        effectiveSeconds: 10,
+        label: 'my label',
+      },
+    })
   })
 
   it('drops empty labels', () => {
-    expect(normalizeWaitRequest({ label: '' }).label).toBeUndefined()
+    const result = createWaitRequest(true, {}, '')
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.value.label).toBeUndefined()
+    }
   })
 
-  it('fails for unknown boolean token', () => {
-    expect(() => normalizeWaitRequest({ enabled: 'disabled' })).toThrow(
-      "Input 'enabled' must be a recognized boolean value.",
-    )
+  it('returns explicit error from duration validation', () => {
+    const result = createWaitRequest(true, { seconds: -1 })
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error.message).toBe(
+        "Input 'seconds' must be a non-negative number.",
+      )
+    }
   })
 })

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -38,7 +38,10 @@ describe('index bootstrap', () => {
       }
       const mockResult: WaitResult = { waited: true, effectiveSeconds: 5 }
 
-      vi.spyOn(readInputsModule, 'readInputs').mockReturnValue(mockRequest)
+      vi.spyOn(readInputsModule, 'readInputs').mockReturnValue({
+        ok: true,
+        value: mockRequest,
+      })
       vi.spyOn(executeWaitModule, 'executeWait').mockResolvedValue(mockResult)
       vi.spyOn(emitOutputsModule, 'emitOutputs').mockImplementation(() => {})
 
@@ -54,6 +57,22 @@ describe('index bootstrap', () => {
       )
       expect(emitOutputsModule.emitOutputs).toHaveBeenCalledWith(mockResult)
       expect(core.debug).toHaveBeenCalledWith('Wait action completed.')
+    })
+
+    it('should log error and exit if inputs are invalid', async () => {
+      vi.spyOn(readInputsModule, 'readInputs').mockReturnValue({
+        ok: false,
+        error: new Error('Invalid inputs'),
+      })
+      vi.spyOn(executeWaitModule, 'executeWait')
+      vi.spyOn(emitOutputsModule, 'emitOutputs')
+
+      await run()
+
+      expect(readInputsModule.readInputs).toHaveBeenCalledOnce()
+      expect(executeWaitModule.executeWait).not.toHaveBeenCalled()
+      expect(emitOutputsModule.emitOutputs).not.toHaveBeenCalled()
+      expect(core.setFailed).toHaveBeenCalledWith('Invalid inputs')
     })
   })
 


### PR DESCRIPTION
Refactored `WaitRequest` and `Duration` to decouple string parsing from core validation, use `Result<T, E>` instead of throwing exceptions, and implement discriminated unions for mutually exclusive duration inputs. Update action adapter and app layer to manage explicit error boundaries explicitly rather than global exception catching.

---
*PR created automatically by Jules for task [15371271238831557381](https://jules.google.com/task/15371271238831557381) started by @akitorahayashi*